### PR TITLE
ユーザープロフィールページの実装とセキュリティ強化

### DIFF
--- a/backend/app/controllers/api/users_controller.rb
+++ b/backend/app/controllers/api/users_controller.rb
@@ -1,0 +1,33 @@
+class Api::UsersController < Api::ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
+  def show
+    user = User.find(params[:id])
+    render json: user.as_json.merge(stats: user.stats)
+  end
+
+  def books
+    user = User.find(params[:id])
+    books = user.books.where(public: true).includes(:category, :tags).order(created_at: :desc)
+    render json: books, include: [:category, :tags]
+  end
+
+  def lists
+    user = User.find(params[:id])
+    lists = user.lists.where(public: true).includes(:books).order(created_at: :desc)
+
+    # リスト内の本も公開本のみにフィルタリング
+    lists_json = lists.as_json(include: :books)
+    lists_json.each do |list|
+      list['books'] = list['books'].select { |book| book['public'] == true }
+    end
+
+    render json: lists_json
+  end
+
+  private
+
+  def record_not_found
+    render json: { error: 'User not found' }, status: :not_found
+  end
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -19,11 +19,19 @@ class User < ApplicationRecord
     raise
   end
 
+  # 読書統計情報を返す
+  def stats
+    {
+      public_books: books.where(public: true).count,
+      public_lists: lists.where(public: true).count
+    }
+  end
+
   private
 
   def self.extract_user_name(payload)
     payload.dig('user_metadata', 'full_name') ||
     payload.dig('user_metadata', 'name') || '名無しさん'
   end
-  
+
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -19,6 +19,12 @@ Rails.application.routes.draw do
     resources :tags, only: %i[index create update destroy]
     resources :statuses, only: %i[index create update destroy]
     resource :profile, only: %i[show update]
+    resources :users, only: %i[show] do
+      member do
+        get :books
+        get :lists
+      end
+    end
   end
 
   # Defines the root path route ("/")

--- a/frontend/src/app/(protected)/books/_components/display/BookListCard.tsx
+++ b/frontend/src/app/(protected)/books/_components/display/BookListCard.tsx
@@ -2,13 +2,27 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { Book } from '@/app/(protected)/books/_types';
 import { CategoryBadge, TagBadge } from '@/components/badges';
+import { ChevronRight } from 'lucide-react';
 
-export default function BookListCard({ book }: { book: Book }) {
+interface BookListCardProps {
+  book: Book;
+  showDetailLink?: boolean;
+}
+
+export default function BookListCard({ book, showDetailLink = true }: BookListCardProps) {
   return (
-    <Link
-      href={`/books/${book.id}`}
-      className="block p-4 bg-white rounded-xl border border-slate-200 hover:shadow-lg hover:-translate-y-1 transition-all"
-    >
+    <div className="relative p-4 bg-white rounded-xl border border-slate-200 hover:shadow-lg transition-all">
+      {/* 詳細ページへのリンク */}
+      {showDetailLink && (
+        <Link
+          href={`/books/${book.id}`}
+          className="absolute top-4 right-4 p-2 rounded-lg bg-slate-100 hover:bg-slate-200 transition-colors"
+          aria-label="書籍の詳細を表示"
+        >
+          <ChevronRight className="w-5 h-5 text-slate-600" />
+        </Link>
+      )}
+
       <div className="flex items-stretch justify-between gap-6">
         {/* 書籍カバー画像 */}
         {book.thumbnail ? (
@@ -68,6 +82,6 @@ export default function BookListCard({ book }: { book: Book }) {
           )}
         </div>
       </div>
-    </Link>
+    </div>
   );
 }

--- a/frontend/src/app/(protected)/books/_components/display/view/BookDetailView.tsx
+++ b/frontend/src/app/(protected)/books/_components/display/view/BookDetailView.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/details';
 import BookActions from '@/app/(protected)/books/_components/detail/BookActions';
 import BookDetailTabs from '@/app/(protected)/books/_components/detail/tab/BookDetailTabs';
+import { useProfile } from '@/hooks/useProfile';
 
 interface BookDetailProps {
   book: BookDetail;
@@ -22,6 +23,10 @@ interface BookDetailProps {
 export default function BookDetailView({ book }: BookDetailProps) {
   const { breadcrumbItems, badges, handleDelete, updateModal, addListModal, cardModal } =
     useBookDetailView(book);
+  const { data: profile } = useProfile();
+
+  // ログインユーザーが本の所有者かどうかを判定
+  const isOwner = profile?.id === book.user_id;
 
   return (
     <>
@@ -38,12 +43,15 @@ export default function BookDetailView({ book }: BookDetailProps) {
           />
           <DetailDescription description={book.description} />
           <DetailMetadata createdAt={book.created_at} updatedAt={book.updated_at} />
-          <BookActions
-            onEdit={updateModal.open}
-            onAddToList={addListModal.open}
-            onCreateCard={cardModal.open}
-            onDelete={() => handleDelete(book.id)}
-          />
+          {/* 所有者の場合のみ編集・削除ボタンを表示 */}
+          {isOwner && (
+            <BookActions
+              onEdit={updateModal.open}
+              onAddToList={addListModal.open}
+              onCreateCard={cardModal.open}
+              onDelete={() => handleDelete(book.id)}
+            />
+          )}
         </DetailCard>
 
         {/* タブ切り替え */}

--- a/frontend/src/app/(protected)/lists/_components/display/AddedBookItem.tsx
+++ b/frontend/src/app/(protected)/lists/_components/display/AddedBookItem.tsx
@@ -10,9 +10,10 @@ import { useListBookMutations } from '@/app/(protected)/listBooks/_hooks/useList
 interface AddedBookProps {
   book: AddedBook;
   listBookId: number;
+  isOwner?: boolean;
 }
 
-export default function AddedBookItem({ book, listBookId }: AddedBookProps) {
+export default function AddedBookItem({ book, listBookId, isOwner = false }: AddedBookProps) {
   const { removeListBook } = useListBookMutations();
 
   return (
@@ -50,13 +51,16 @@ export default function AddedBookItem({ book, listBookId }: AddedBookProps) {
               </p>
             )}
           </div>
-          <Button
-            variant="danger"
-            onClick={() => removeListBook({ id: listBookId })}
-            icon={<Trash2 size={18} />}
-          >
-            リストから削除
-          </Button>
+          {/* 所有者の場合のみ削除ボタンを表示 */}
+          {isOwner && (
+            <Button
+              variant="danger"
+              onClick={() => removeListBook({ id: listBookId })}
+              icon={<Trash2 size={18} />}
+            >
+              リストから削除
+            </Button>
+          )}
         </div>
 
         {/* 評価（星） */}
@@ -71,15 +75,17 @@ export default function AddedBookItem({ book, listBookId }: AddedBookProps) {
         {/* 説明 */}
         {book.description && <p className="text-sm text-slate-700 flex-1">{book.description}</p>}
 
-        {/* 詳細ページへのリンク */}
-        <div className="mt-4 flex justify-between items-center">
-          <Link
-            href={`/books/${book.id}`}
-            className="text-sm font-semibold text-primary hover:underline"
-          >
-            詳細を見る
-          </Link>
-        </div>
+        {/* 詳細ページへのリンク（所有者のみ） */}
+        {isOwner && (
+          <div className="mt-4 flex justify-between items-center">
+            <Link
+              href={`/books/${book.id}`}
+              className="text-sm font-semibold text-primary hover:underline"
+            >
+              詳細を見る
+            </Link>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/app/(protected)/lists/_components/display/AddedBooks.tsx
+++ b/frontend/src/app/(protected)/lists/_components/display/AddedBooks.tsx
@@ -8,9 +8,10 @@ import EmptyState from '@/components/feedback/EmptyState';
 interface AddedBooksProps {
   books: AddedBook[];
   listBooks: ListBook[];
+  isOwner?: boolean;
 }
 
-export default function AddedBooks({ books, listBooks }: AddedBooksProps) {
+export default function AddedBooks({ books, listBooks, isOwner = false }: AddedBooksProps) {
   return (
     <section className="space-y-4">
       {/* 見出し */}
@@ -27,7 +28,9 @@ export default function AddedBooks({ books, listBooks }: AddedBooksProps) {
             const listBook = listBooks.find((lb) => lb.book_id === book.id);
             if (!listBook) return null;
 
-            return <AddedBookItem key={book.id} book={book} listBookId={listBook.id} />;
+            return (
+              <AddedBookItem key={book.id} book={book} listBookId={listBook.id} isOwner={isOwner} />
+            );
           })}
         </div>
       )}

--- a/frontend/src/app/(protected)/lists/_components/display/view/ListDetailView.tsx
+++ b/frontend/src/app/(protected)/lists/_components/display/view/ListDetailView.tsx
@@ -10,9 +10,11 @@ import {
   DetailHeader,
   DetailDescription,
   DetailMetadata,
+  DetailOwner,
 } from '@/components/details';
 import ListActions from '@/app/(protected)/lists/_components/detail/ListActions';
 import { ListDetail } from '@/schemas/list';
+import { useProfile } from '@/hooks/useProfile';
 
 interface ListDetailProps {
   list: ListDetail;
@@ -21,33 +23,50 @@ interface ListDetailProps {
 export default function ListDetailView({ list }: ListDetailProps) {
   const { breadcrumbItems, badges, handleDelete, updateModal, addBookModal } =
     useListDetailView(list);
+  const { data: profile } = useProfile();
+
+  // ログインユーザーがリストの所有者かどうかを判定
+  const isOwner = profile?.id === list.user_id;
 
   return (
     <>
-      <DetailContainer breadcrumbItems={breadcrumbItems}>
+      <DetailContainer breadcrumbItems={isOwner ? breadcrumbItems : undefined}>
+        {/* 所有者でない場合、ユーザー名を表示 */}
+        {!isOwner && <DetailOwner userId={list.user_id} name={list.user.name} />}
         <DetailCard>
           <DetailHeader title={list.name} badges={badges} />
           <DetailDescription description={list.description} />
           <DetailMetadata createdAt={list.created_at} updatedAt={list.updated_at} />
-          <ListActions
-            onEdit={updateModal.open}
-            onAddBook={addBookModal.open}
-            onDelete={() => handleDelete(list.id)}
-          />
+          {/* 所有者の場合のみ編集・削除ボタンを表示 */}
+          {isOwner && (
+            <ListActions
+              onEdit={updateModal.open}
+              onAddBook={addBookModal.open}
+              onDelete={() => handleDelete(list.id)}
+            />
+          )}
         </DetailCard>
 
         {/* 追加済みの本 */}
-        <AddedBooks books={list.books} listBooks={list.list_books} />
+        <AddedBooks books={list.books} listBooks={list.list_books} isOwner={isOwner} />
       </DetailContainer>
 
-      {/* モーダル */}
-      <UpdateListFormModal list={list} isOpen={updateModal.isOpen} onClose={updateModal.close} />
-      <AddBookModal
-        listId={list.id}
-        bookIds={list.books.map((book) => book.id)}
-        isOpen={addBookModal.isOpen}
-        onClose={addBookModal.close}
-      />
+      {/* 所有者の場合のみモーダルを表示できるようにする */}
+      {isOwner && (
+        <>
+          <UpdateListFormModal
+            list={list}
+            isOpen={updateModal.isOpen}
+            onClose={updateModal.close}
+          />
+          <AddBookModal
+            listId={list.id}
+            bookIds={list.books.map((book) => book.id)}
+            isOpen={addBookModal.isOpen}
+            onClose={addBookModal.close}
+          />
+        </>
+      )}
     </>
   );
 }

--- a/frontend/src/app/(protected)/users/[id]/page.tsx
+++ b/frontend/src/app/(protected)/users/[id]/page.tsx
@@ -1,0 +1,50 @@
+import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
+import { createServerQueryClient } from '@/lib/queryClient';
+import { queryKeys } from '@/constants/queryKeys';
+import UserDetailClient from '@/app/(protected)/users/_components/clients/UserDetailClient';
+import { authenticatedRequest } from '@/supabase/dal';
+import { userWithStatsSchema } from '@/app/(protected)/users/_types';
+import { bookSchema } from '@/schemas/book';
+import { listSchema } from '@/schemas/list';
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function UserPage({ params }: Props) {
+  const { id } = await params;
+  const queryClient = createServerQueryClient();
+
+  // ユーザー情報をprefetch
+  await queryClient.prefetchQuery({
+    queryKey: queryKeys.users.detail(id),
+    queryFn: async () => {
+      const data = await authenticatedRequest(`/users/${id}`);
+      return userWithStatsSchema.parse(data);
+    },
+  });
+
+  // ユーザーの公開本一覧をprefetch
+  await queryClient.prefetchQuery({
+    queryKey: queryKeys.users.books(id),
+    queryFn: async () => {
+      const data = await authenticatedRequest(`/users/${id}/books`);
+      return bookSchema.array().parse(data);
+    },
+  });
+
+  // ユーザーの公開リスト一覧をprefetch
+  await queryClient.prefetchQuery({
+    queryKey: queryKeys.users.lists(id),
+    queryFn: async () => {
+      const data = await authenticatedRequest(`/users/${id}/lists`);
+      return listSchema.array().parse(data);
+    },
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <UserDetailClient id={id} />
+    </HydrationBoundary>
+  );
+}

--- a/frontend/src/app/(protected)/users/_components/clients/UserDetailClient.test.tsx
+++ b/frontend/src/app/(protected)/users/_components/clients/UserDetailClient.test.tsx
@@ -1,0 +1,191 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useUser, useUserBooks, useUserLists } from '@/app/(protected)/users/_hooks';
+import UserDetailClient from './UserDetailClient';
+import { createMockBook, createMockList, createMockUserWithStats } from '@/test/factories';
+
+vi.mock('@/app/(protected)/users/_hooks', () => ({
+  useUser: vi.fn(),
+  useUserBooks: vi.fn(),
+  useUserLists: vi.fn(),
+}));
+
+describe('UserDetailClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('ユーザープロフィール', () => {
+    it('読み込み中の表示がされる', () => {
+      vi.mocked(useUser).mockReturnValue({
+        data: undefined,
+        error: null,
+        isLoading: true,
+      } as unknown as ReturnType<typeof useUser>);
+      vi.mocked(useUserBooks).mockReturnValue({} as unknown as ReturnType<typeof useUserBooks>);
+      vi.mocked(useUserLists).mockReturnValue({} as unknown as ReturnType<typeof useUserLists>);
+
+      render(<UserDetailClient id="1" />);
+
+      expect(screen.getByText('ユーザー情報を読み込んでいます...')).toBeInTheDocument();
+    });
+
+    it('エラー時にメッセージが表示される', () => {
+      vi.mocked(useUser).mockReturnValue({
+        data: undefined,
+        error: new Error('エラーのテスト'),
+        isLoading: false,
+      } as unknown as ReturnType<typeof useUser>);
+      vi.mocked(useUserBooks).mockReturnValue({} as unknown as ReturnType<typeof useUserBooks>);
+      vi.mocked(useUserLists).mockReturnValue({} as unknown as ReturnType<typeof useUserLists>);
+
+      render(<UserDetailClient id="1" />);
+
+      expect(screen.getByText('エラーのテスト')).toBeInTheDocument();
+    });
+
+    it('エラーメッセージが設定されていない場合、デフォルトのエラーメッセージが表示される', () => {
+      vi.mocked(useUser).mockReturnValue({
+        data: undefined,
+        error: new Error(),
+        isLoading: false,
+      } as unknown as ReturnType<typeof useUser>);
+      vi.mocked(useUserBooks).mockReturnValue({} as unknown as ReturnType<typeof useUserBooks>);
+      vi.mocked(useUserLists).mockReturnValue({} as unknown as ReturnType<typeof useUserLists>);
+
+      render(<UserDetailClient id="1" />);
+
+      expect(screen.getByText('エラーが発生しました')).toBeInTheDocument();
+    });
+
+    it('ユーザー名が表示される', () => {
+      vi.mocked(useUser).mockReturnValue({
+        data: createMockUserWithStats({ name: 'テストユーザー' }),
+        error: null,
+        isLoading: false,
+      } as unknown as ReturnType<typeof useUser>);
+      vi.mocked(useUserBooks).mockReturnValue({} as unknown as ReturnType<typeof useUserBooks>);
+      vi.mocked(useUserLists).mockReturnValue({} as unknown as ReturnType<typeof useUserLists>);
+
+      render(<UserDetailClient id="1" />);
+
+      expect(screen.getByText('テストユーザー')).toBeInTheDocument();
+    });
+  });
+
+  describe('本の表示', () => {
+    it('読み込み中の表示がされる', () => {
+      vi.mocked(useUserBooks).mockReturnValue({
+        data: undefined,
+        error: null,
+        isLoading: true,
+      } as unknown as ReturnType<typeof useUserBooks>);
+      vi.mocked(useUser).mockReturnValue({} as unknown as ReturnType<typeof useUser>);
+      vi.mocked(useUserLists).mockReturnValue({} as unknown as ReturnType<typeof useUserLists>);
+
+      render(<UserDetailClient id="1" />);
+
+      expect(screen.getByText('本を読み込んでいます...')).toBeInTheDocument();
+    });
+
+    it('エラー時にメッセージが表示される', () => {
+      vi.mocked(useUserBooks).mockReturnValue({
+        data: undefined,
+        error: new Error('エラーのテスト'),
+        isLoading: false,
+      } as unknown as ReturnType<typeof useUserBooks>);
+      vi.mocked(useUser).mockReturnValue({} as unknown as ReturnType<typeof useUser>);
+      vi.mocked(useUserLists).mockReturnValue({} as unknown as ReturnType<typeof useUserLists>);
+
+      render(<UserDetailClient id="1" />);
+
+      expect(screen.getByText('エラーのテスト')).toBeInTheDocument();
+    });
+
+    it('エラーメッセージが設定されていない場合、デフォルトのエラーメッセージが表示される', () => {
+      vi.mocked(useUserBooks).mockReturnValue({
+        data: undefined,
+        error: new Error(),
+        isLoading: false,
+      } as unknown as ReturnType<typeof useUserBooks>);
+      vi.mocked(useUser).mockReturnValue({} as unknown as ReturnType<typeof useUser>);
+      vi.mocked(useUserLists).mockReturnValue({} as unknown as ReturnType<typeof useUserLists>);
+
+      render(<UserDetailClient id="1" />);
+
+      expect(screen.getByText('本の取得に失敗しました')).toBeInTheDocument();
+    });
+
+    it('本一覧が表示される', () => {
+      vi.mocked(useUserBooks).mockReturnValue({
+        data: [createMockBook({ title: 'テスト本A' })],
+        error: null,
+        isLoading: false,
+      } as unknown as ReturnType<typeof useUserBooks>);
+      vi.mocked(useUser).mockReturnValue({} as unknown as ReturnType<typeof useUser>);
+      vi.mocked(useUserLists).mockReturnValue({} as unknown as ReturnType<typeof useUserLists>);
+
+      render(<UserDetailClient id="1" />);
+
+      expect(screen.getByText('本一覧')).toBeInTheDocument();
+    });
+  });
+
+  describe('リストの表示', () => {
+    it('読み込み中の表示がされる', () => {
+      vi.mocked(useUserLists).mockReturnValue({
+        data: undefined,
+        error: null,
+        isLoading: true,
+      } as unknown as ReturnType<typeof useUserLists>);
+      vi.mocked(useUser).mockReturnValue({} as unknown as ReturnType<typeof useUser>);
+      vi.mocked(useUserBooks).mockReturnValue({} as unknown as ReturnType<typeof useUserBooks>);
+
+      render(<UserDetailClient id="1" />);
+
+      expect(screen.getByText('リストを読み込んでいます...')).toBeInTheDocument();
+    });
+
+    it('エラー時にメッセージが表示される', () => {
+      vi.mocked(useUserLists).mockReturnValue({
+        data: undefined,
+        error: new Error('エラーのテスト'),
+        isLoading: false,
+      } as unknown as ReturnType<typeof useUserLists>);
+      vi.mocked(useUser).mockReturnValue({} as unknown as ReturnType<typeof useUser>);
+      vi.mocked(useUserBooks).mockReturnValue({} as unknown as ReturnType<typeof useUserBooks>);
+
+      render(<UserDetailClient id="1" />);
+
+      expect(screen.getByText('エラーのテスト')).toBeInTheDocument();
+    });
+
+    it('エラーメッセージが設定されていない場合、デフォルトのエラーメッセージが表示される', () => {
+      vi.mocked(useUserLists).mockReturnValue({
+        data: undefined,
+        error: new Error(),
+        isLoading: false,
+      } as unknown as ReturnType<typeof useUserLists>);
+      vi.mocked(useUser).mockReturnValue({} as unknown as ReturnType<typeof useUser>);
+      vi.mocked(useUserBooks).mockReturnValue({} as unknown as ReturnType<typeof useUserBooks>);
+
+      render(<UserDetailClient id="1" />);
+
+      expect(screen.getByText('リストの取得に失敗しました')).toBeInTheDocument();
+    });
+
+    it('公開リストが表示される', () => {
+      vi.mocked(useUserLists).mockReturnValue({
+        data: [createMockList({ name: 'テストリスト' })],
+        error: null,
+        isLoading: false,
+      } as unknown as ReturnType<typeof useUserLists>);
+      vi.mocked(useUser).mockReturnValue({} as unknown as ReturnType<typeof useUser>);
+      vi.mocked(useUserBooks).mockReturnValue({} as unknown as ReturnType<typeof useUserBooks>);
+
+      render(<UserDetailClient id="1" />);
+
+      expect(screen.getByText('公開リスト')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/app/(protected)/users/_components/clients/UserDetailClient.tsx
+++ b/frontend/src/app/(protected)/users/_components/clients/UserDetailClient.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useUser, useUserBooks, useUserLists } from '@/app/(protected)/users/_hooks';
+import {
+  UserProfileView,
+  UserBooksView,
+  UserListsView,
+} from '@/app/(protected)/users/_components/display/view';
+import { ErrorMessage, LoadingState } from '@/components/feedback';
+
+type Props = {
+  id: string;
+};
+
+export default function UserDetailClient({ id }: Props) {
+  const { data: user, error: userError, isLoading: isUserLoading } = useUser(id);
+  const { data: books, error: booksError, isLoading: isBooksLoading } = useUserBooks(id);
+  const { data: lists, error: listsError, isLoading: isListsLoading } = useUserLists(id);
+
+  return (
+    <div className="space-y-8">
+      {/* ユーザープロフィール */}
+      <div>
+        {isUserLoading ? (
+          <LoadingState message="ユーザー情報を読み込んでいます..." />
+        ) : userError ? (
+          <ErrorMessage message={userError?.message || 'エラーが発生しました'} />
+        ) : user ? (
+          <UserProfileView user={user} />
+        ) : null}
+      </div>
+
+      {/* 公開している本 */}
+      <div>
+        {isBooksLoading ? (
+          <LoadingState message="本を読み込んでいます..." />
+        ) : booksError ? (
+          <ErrorMessage message={booksError?.message || '本の取得に失敗しました'} />
+        ) : books ? (
+          <UserBooksView books={books} />
+        ) : null}
+      </div>
+
+      {/* 公開しているリスト */}
+      <div>
+        {isListsLoading ? (
+          <LoadingState message="リストを読み込んでいます..." />
+        ) : listsError ? (
+          <ErrorMessage message={listsError?.message || 'リストの取得に失敗しました'} />
+        ) : lists ? (
+          <UserListsView lists={lists} />
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(protected)/users/_components/display/view/UserBooksView.test.tsx
+++ b/frontend/src/app/(protected)/users/_components/display/view/UserBooksView.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Book } from '@/schemas/book';
+import { createMockBook } from '@/test/factories';
+import { createTestUuid } from '@/test/helpers';
+import UserBooksView from './UserBooksView';
+
+describe('UserBooksView', () => {
+  describe('レイアウト', () => {
+    it('タイトル「本一覧」が表示される', () => {
+      const books: Book[] = [createMockBook()];
+
+      render(<UserBooksView books={books} />);
+
+      expect(screen.getByRole('heading', { name: '本一覧' })).toBeInTheDocument();
+    });
+  });
+
+  describe('本リストのレンダリング', () => {
+    it('本が1冊の場合、その本のタイトルが表示される', () => {
+      const books: Book[] = [
+        createMockBook({
+          id: createTestUuid(1),
+          title: 'テスト本1',
+        }),
+      ];
+
+      render(<UserBooksView books={books} />);
+
+      // タイトルが表示されていることを確認（BookListCardがレンダリングされている）
+      expect(screen.getByText('テスト本1')).toBeInTheDocument();
+    });
+
+    it('本が複数冊の場合、すべての本のタイトルが表示される', () => {
+      const books: Book[] = [
+        createMockBook({
+          id: createTestUuid(1),
+          title: 'テスト本1',
+        }),
+        createMockBook({
+          id: createTestUuid(2),
+          title: 'テスト本2',
+        }),
+      ];
+
+      render(<UserBooksView books={books} />);
+
+      // 各本のタイトルが表示されていることを確認
+      // （BookListCardの表示の詳細はBookListCard.test.tsxでテストする）
+      expect(screen.getByText('テスト本1')).toBeInTheDocument();
+      expect(screen.getByText('テスト本2')).toBeInTheDocument();
+    });
+  });
+
+  describe('本が存在しない場合', () => {
+    it('タイトルは表示される', () => {
+      render(<UserBooksView books={[]} />);
+
+      expect(screen.getByRole('heading', { name: '本一覧' })).toBeInTheDocument();
+    });
+
+    it('空の状態メッセージが表示される', () => {
+      render(<UserBooksView books={[]} />);
+
+      expect(screen.getByText('公開している本はありません')).toBeInTheDocument();
+    });
+  });
+
+  describe('エラーハンドリング', () => {
+    it('空配列の books が渡されてもエラーにならない', () => {
+      expect(() => render(<UserBooksView books={[]} />)).not.toThrow();
+    });
+  });
+});

--- a/frontend/src/app/(protected)/users/_components/display/view/UserBooksView.tsx
+++ b/frontend/src/app/(protected)/users/_components/display/view/UserBooksView.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Book } from '@/schemas/book';
+import BookListCard from '@/app/(protected)/books/_components/display/BookListCard';
+
+interface UserBooksViewProps {
+  books: Book[];
+}
+
+export default function UserBooksView({ books }: UserBooksViewProps) {
+  return (
+    <div className="space-y-6">
+      <h2 className="text-2xl font-bold">本一覧</h2>
+      {books.length === 0 ? (
+        <p className="text-slate-500 text-center py-8">公開している本はありません</p>
+      ) : (
+        <div className="space-y-4">
+          {books.map((book) => (
+            <BookListCard key={book.id} book={book} showDetailLink={false} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/(protected)/users/_components/display/view/UserListsView.test.tsx
+++ b/frontend/src/app/(protected)/users/_components/display/view/UserListsView.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { createMockList } from '@/test/factories';
+import { createTestUuid } from '@/test/helpers';
+import UserListsView from './UserListsView';
+
+describe('UserListsView', () => {
+  describe('レイアウト', () => {
+    it('タイトル「公開リスト」が表示される', () => {
+      const lists = [createMockList()];
+
+      render(<UserListsView lists={lists} />);
+
+      expect(screen.getByRole('heading', { name: '公開リスト' })).toBeInTheDocument();
+    });
+  });
+
+  describe('リストのレンダリング', () => {
+    it('リストが一つの場合、そのリストのタイトルが表示される', () => {
+      const lists = [
+        createMockList({
+          id: createTestUuid(1),
+          name: 'テストリスト',
+        }),
+      ];
+
+      render(<UserListsView lists={lists} />);
+
+      expect(screen.getByText('テストリスト')).toBeInTheDocument();
+    });
+
+    it('リストが複数存在する場合、全てのリストのタイトルが表示される', () => {
+      const lists = [
+        createMockList({
+          id: createTestUuid(1),
+          name: 'テストリスト1',
+        }),
+        createMockList({
+          id: createTestUuid(2),
+          name: 'テストリスト2',
+        }),
+      ];
+
+      render(<UserListsView lists={lists} />);
+
+      expect(screen.getByText('テストリスト1')).toBeInTheDocument();
+      expect(screen.getByText('テストリスト2')).toBeInTheDocument();
+    });
+  });
+
+  describe('リストが存在しない場合', () => {
+    it('タイトルは表示される', () => {
+      render(<UserListsView lists={[]} />);
+
+      expect(screen.getByRole('heading', { name: '公開リスト' })).toBeInTheDocument();
+    });
+
+    it('空の状態メッセージが表示される', () => {
+      render(<UserListsView lists={[]} />);
+
+      expect(screen.getByText('公開しているリストはありません')).toBeInTheDocument();
+    });
+  });
+
+  describe('エラーハンドリング', () => {
+    it('空配列の lists が渡されてもエラーにならない', () => {
+      expect(() => render(<UserListsView lists={[]} />)).not.toThrow();
+    });
+  });
+});

--- a/frontend/src/app/(protected)/users/_components/display/view/UserListsView.tsx
+++ b/frontend/src/app/(protected)/users/_components/display/view/UserListsView.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { List } from '@/schemas/list';
+import ListCard from '@/app/(protected)/lists/_components/display/ListCard';
+
+interface UserListsViewProps {
+  lists: List[];
+}
+
+export default function UserListsView({ lists }: UserListsViewProps) {
+  return (
+    <div className="space-y-6">
+      <h2 className="text-2xl font-bold">公開リスト</h2>
+      {lists.length === 0 ? (
+        <p className="text-slate-500 text-center py-8">公開しているリストはありません</p>
+      ) : (
+        <div className="space-y-4">
+          {lists.map((list) => (
+            <ListCard key={list.id} list={list} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/(protected)/users/_components/display/view/UserProfileView.test.tsx
+++ b/frontend/src/app/(protected)/users/_components/display/view/UserProfileView.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { createMockUserWithStats } from '@/test/factories';
+import UserProfileView from './UserProfileView';
+
+describe('UserProfileView', () => {
+  describe('レイアウト', () => {
+    it('ユーザー名が表示されている', () => {
+      const user = createMockUserWithStats({ name: 'テストユーザー' });
+
+      render(<UserProfileView user={user} />);
+
+      expect(screen.getByRole('heading', { name: 'テストユーザー' })).toBeInTheDocument();
+    });
+  });
+
+  describe('統計情報の表示', () => {
+    it('公開している本の数が表示される', () => {
+      const user = createMockUserWithStats({
+        name: 'テストユーザー',
+        stats: { public_books: 5, public_lists: 2 },
+      });
+
+      render(<UserProfileView user={user} />);
+
+      expect(screen.getByText('公開している本')).toBeInTheDocument();
+      expect(screen.getByText('5')).toBeInTheDocument();
+    });
+
+    it('公開しているリストの数が表示される', () => {
+      const user = createMockUserWithStats({
+        name: 'テストユーザー',
+        stats: { public_books: 5, public_lists: 2 },
+      });
+
+      render(<UserProfileView user={user} />);
+
+      expect(screen.getByText('公開しているリスト')).toBeInTheDocument();
+      expect(screen.getByText('2')).toBeInTheDocument();
+    });
+
+    it('公開している本が無い場合、0 と表示される', () => {
+      const user = createMockUserWithStats({
+        name: 'テストユーザー',
+        stats: { public_books: 0, public_lists: 2 },
+      });
+
+      render(<UserProfileView user={user} />);
+
+      expect(screen.getByText('公開している本')).toBeInTheDocument();
+      expect(screen.getByText('0')).toBeInTheDocument();
+    });
+
+    it('公開しているリストが無い場合、0 と表示される', () => {
+      const user = createMockUserWithStats({
+        name: 'テストユーザー',
+        stats: { public_books: 5, public_lists: 0 },
+      });
+
+      render(<UserProfileView user={user} />);
+
+      expect(screen.getByText('公開しているリスト')).toBeInTheDocument();
+      expect(screen.getByText('0')).toBeInTheDocument();
+    });
+  });
+
+  describe('プロフィール画像の表示', () => {
+    it('プロフィール画像が存在する場合、画像が表示される', () => {
+      const user = createMockUserWithStats({
+        name: 'テストユーザー',
+        avatar_url: 'http://testImage.com',
+      });
+
+      render(<UserProfileView user={user} />);
+
+      expect(screen.getByRole('img')).toBeInTheDocument();
+    });
+
+    it('プロフィール画像が無い場合、ユーザー名の頭文字が表示される', () => {
+      const user = createMockUserWithStats({ name: 'テストユーザー' });
+
+      render(<UserProfileView user={user} />);
+
+      expect(screen.getByTestId('initial')).toHaveTextContent('テ');
+    });
+  });
+});

--- a/frontend/src/app/(protected)/users/_components/display/view/UserProfileView.tsx
+++ b/frontend/src/app/(protected)/users/_components/display/view/UserProfileView.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import Image from 'next/image';
+import { BookOpen, List } from 'lucide-react';
+import { UserWithStats } from '@/app/(protected)/users/_types';
+import PageTitle from '@/components/layout/PageTitle';
+
+interface UserProfileViewProps {
+  user: UserWithStats;
+}
+
+export default function UserProfileView({ user }: UserProfileViewProps) {
+  return (
+    <div className="space-y-6">
+      <PageTitle title={user.name} />
+
+      {/* ユーザープロフィールカード */}
+      <div className="bg-white rounded-lg border border-slate-200 p-8">
+        <div className="flex flex-col items-center">
+          {/* プロフィール画像 or 頭文字 */}
+          {user.avatar_url ? (
+            <Image
+              src={user.avatar_url}
+              alt={user.name}
+              width={128}
+              height={128}
+              className="w-32 h-32 rounded-full object-cover mb-4"
+            />
+          ) : (
+            <div className="flex items-center justify-center w-32 h-32 rounded-full bg-primary text-white text-5xl font-bold mb-4">
+              {user.name.charAt(0).toUpperCase()}
+            </div>
+          )}
+
+          {/* ユーザー名 */}
+          <h2 className="text-2xl font-bold text-slate-900 mb-6">{user.name}</h2>
+
+          {/* 統計情報 */}
+          <div className="flex gap-8">
+            {/* 公開している本 */}
+            <div className="flex flex-col items-center">
+              <div className="flex items-center gap-2 mb-1">
+                <BookOpen className="w-5 h-5 text-slate-600" />
+                <span className="text-2xl font-bold text-slate-900">{user.stats.public_books}</span>
+              </div>
+              <span className="text-sm text-slate-600">公開している本</span>
+            </div>
+
+            {/* 公開しているリスト */}
+            <div className="flex flex-col items-center">
+              <div className="flex items-center gap-2 mb-1">
+                <List className="w-5 h-5 text-slate-600" />
+                <span className="text-2xl font-bold text-slate-900">{user.stats.public_lists}</span>
+              </div>
+              <span className="text-sm text-slate-600">公開しているリスト</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(protected)/users/_components/display/view/UserProfileView.tsx
+++ b/frontend/src/app/(protected)/users/_components/display/view/UserProfileView.tsx
@@ -3,7 +3,6 @@
 import Image from 'next/image';
 import { BookOpen, List } from 'lucide-react';
 import { UserWithStats } from '@/app/(protected)/users/_types';
-import PageTitle from '@/components/layout/PageTitle';
 
 interface UserProfileViewProps {
   user: UserWithStats;
@@ -12,8 +11,6 @@ interface UserProfileViewProps {
 export default function UserProfileView({ user }: UserProfileViewProps) {
   return (
     <div className="space-y-6">
-      <PageTitle title={user.name} />
-
       {/* ユーザープロフィールカード */}
       <div className="bg-white rounded-lg border border-slate-200 p-8">
         <div className="flex flex-col items-center">
@@ -28,7 +25,7 @@ export default function UserProfileView({ user }: UserProfileViewProps) {
             />
           ) : (
             <div className="flex items-center justify-center w-32 h-32 rounded-full bg-primary text-white text-5xl font-bold mb-4">
-              {user.name.charAt(0).toUpperCase()}
+              <span data-testid="initial">{user.name.charAt(0).toUpperCase()}</span>
             </div>
           )}
 

--- a/frontend/src/app/(protected)/users/_components/display/view/index.ts
+++ b/frontend/src/app/(protected)/users/_components/display/view/index.ts
@@ -1,0 +1,3 @@
+export { default as UserProfileView } from './UserProfileView';
+export { default as UserBooksView } from './UserBooksView';
+export { default as UserListsView } from './UserListsView';

--- a/frontend/src/app/(protected)/users/_hooks/index.ts
+++ b/frontend/src/app/(protected)/users/_hooks/index.ts
@@ -1,0 +1,3 @@
+export { useUser } from '@/app/(protected)/users/_hooks/useUser';
+export { useUserBooks } from '@/app/(protected)/users/_hooks/useUserBooks';
+export { useUserLists } from '@/app/(protected)/users/_hooks/useUserLists';

--- a/frontend/src/app/(protected)/users/_hooks/useUser.test.tsx
+++ b/frontend/src/app/(protected)/users/_hooks/useUser.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createProvider } from '@/test/helpers';
+import { createMockUserWithStats } from '@/test/factories';
+import { useUser } from './useUser';
+import { fetchUser } from '@/app/(protected)/users/_lib/fetchUser';
+
+// fetchUserをモック化
+vi.mock('@/app/(protected)/users/_lib/fetchUser');
+
+describe('useUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('成功時', () => {
+    it('fetchUserを呼び出してデータを取得する', async () => {
+      const mockUser = createMockUserWithStats({
+        id: 1,
+        name: 'テストユーザー',
+        stats: {
+          public_books: 10,
+          public_lists: 5,
+        },
+      });
+
+      vi.mocked(fetchUser).mockResolvedValue(mockUser);
+
+      const { result } = renderHook(() => useUser('1'), {
+        wrapper: createProvider(),
+      });
+
+      // 初期状態: ローディング中
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.data).toBeUndefined();
+
+      // データ取得完了を待つ
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      // 成功状態を確認
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isSuccess).toBe(true);
+      expect(result.current.error).toBeNull();
+      expect(result.current.data).toEqual(mockUser);
+
+      // fetchUserが正しい引数で呼ばれたことを確認
+      expect(fetchUser).toHaveBeenCalledWith('1');
+      expect(fetchUser).toHaveBeenCalledTimes(1);
+    });
+
+    it('idが空文字列の時、クエリを実行しない', () => {
+      const { result } = renderHook(() => useUser(''), {
+        wrapper: createProvider(),
+      });
+
+      // クエリが無効化されているため、データ取得が行われない
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(result.current.data).toBeUndefined();
+
+      // fetchUserが呼ばれていないことを確認
+      expect(fetchUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('エラー時', () => {
+    it('fetchUserがエラーをスローした場合、エラー状態になる', async () => {
+      vi.mocked(fetchUser).mockRejectedValue(new Error('ユーザー情報の取得に失敗しました'));
+
+      const { result } = renderHook(() => useUser('1'), {
+        wrapper: createProvider(),
+      });
+
+      // 初期状態: ローディング中
+      expect(result.current.isLoading).toBe(true);
+
+      // エラー完了を待つ
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      // エラー状態を確認
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.data).toBeUndefined();
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error?.message).toBe('ユーザー情報の取得に失敗しました');
+    });
+  });
+
+  describe('React Queryの動作', () => {
+    it('正しいqueryKeyを使用する', async () => {
+      vi.mocked(fetchUser).mockResolvedValue(createMockUserWithStats());
+
+      const { result } = renderHook(() => useUser('42'), {
+        wrapper: createProvider(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      // fetchUserが正しいidで呼ばれたことを確認
+      expect(fetchUser).toHaveBeenCalledWith('42');
+    });
+  });
+});

--- a/frontend/src/app/(protected)/users/_hooks/useUser.ts
+++ b/frontend/src/app/(protected)/users/_hooks/useUser.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '@/constants/queryKeys';
+import { fetchUser } from '@/app/(protected)/users/_lib/fetchUser';
+
+export function useUser(id: string) {
+  return useQuery({
+    queryKey: queryKeys.users.detail(id),
+    queryFn: () => fetchUser(id),
+    enabled: !!id,
+  });
+}

--- a/frontend/src/app/(protected)/users/_hooks/useUserBooks.test.tsx
+++ b/frontend/src/app/(protected)/users/_hooks/useUserBooks.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createProvider, createTestUuid } from '@/test/helpers';
+import { createMockBook } from '@/test/factories';
+import { useUserBooks } from './useUserBooks';
+import { fetchUserBooks } from '@/app/(protected)/users/_lib/fetchUserBooks';
+
+// fetchUserBooksをモック化
+vi.mock('@/app/(protected)/users/_lib/fetchUserBooks');
+
+describe('useUserBooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('成功時', () => {
+    it('fetchUserBooksを呼び出してデータを取得する', async () => {
+      const mockBooks = [
+        createMockBook({
+          id: createTestUuid(1),
+          title: 'テスト本1',
+          public: true,
+        }),
+        createMockBook({
+          id: createTestUuid(2),
+          title: 'テスト本2',
+          public: true,
+        }),
+      ];
+
+      vi.mocked(fetchUserBooks).mockResolvedValue(mockBooks);
+
+      const { result } = renderHook(() => useUserBooks('1'), {
+        wrapper: createProvider(),
+      });
+
+      // 初期状態: ローディング中
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.data).toBeUndefined();
+
+      // データ取得完了を待つ
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      // 成功状態を確認
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isSuccess).toBe(true);
+      expect(result.current.error).toBeNull();
+      expect(result.current.data).toEqual(mockBooks);
+      expect(result.current.data).toHaveLength(2);
+
+      // fetchUserBooksが正しい引数で呼ばれたことを確認
+      expect(fetchUserBooks).toHaveBeenCalledWith('1');
+      expect(fetchUserBooks).toHaveBeenCalledTimes(1);
+    });
+
+    it('idが空文字列の時、クエリを実行しない', () => {
+      const { result } = renderHook(() => useUserBooks(''), {
+        wrapper: createProvider(),
+      });
+
+      // クエリが無効化されているため、データ取得が行われない
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(result.current.data).toBeUndefined();
+
+      // fetchUserBooksが呼ばれていないことを確認
+      expect(fetchUserBooks).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('エラー時', () => {
+    it('fetchUserBooksがエラーをスローした場合、エラー状態になる', async () => {
+      vi.mocked(fetchUserBooks).mockRejectedValue(
+        new Error('ユーザーの公開本一覧の取得に失敗しました'),
+      );
+
+      const { result } = renderHook(() => useUserBooks('1'), {
+        wrapper: createProvider(),
+      });
+
+      // 初期状態: ローディング中
+      expect(result.current.isLoading).toBe(true);
+
+      // エラー完了を待つ
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      // エラー状態を確認
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.data).toBeUndefined();
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error?.message).toBe('ユーザーの公開本一覧の取得に失敗しました');
+    });
+  });
+
+  describe('React Queryの動作', () => {
+    it('正しいqueryKeyを使用する', async () => {
+      vi.mocked(fetchUserBooks).mockResolvedValue([]);
+
+      const { result } = renderHook(() => useUserBooks('42'), {
+        wrapper: createProvider(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      // fetchUserBooksが正しいidで呼ばれたことを確認
+      expect(fetchUserBooks).toHaveBeenCalledWith('42');
+    });
+  });
+});

--- a/frontend/src/app/(protected)/users/_hooks/useUserBooks.ts
+++ b/frontend/src/app/(protected)/users/_hooks/useUserBooks.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '@/constants/queryKeys';
+import { fetchUserBooks } from '@/app/(protected)/users/_lib/fetchUserBooks';
+
+export function useUserBooks(id: string) {
+  return useQuery({
+    queryKey: queryKeys.users.books(id),
+    queryFn: () => fetchUserBooks(id),
+    enabled: !!id,
+  });
+}

--- a/frontend/src/app/(protected)/users/_hooks/useUserLists.test.tsx
+++ b/frontend/src/app/(protected)/users/_hooks/useUserLists.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createProvider, createTestUuid } from '@/test/helpers';
+import { createMockList } from '@/test/factories';
+import { useUserLists } from './useUserLists';
+import { fetchUserLists } from '@/app/(protected)/users/_lib/fetchUserLists';
+
+// fetchUserListsをモック化
+vi.mock('@/app/(protected)/users/_lib/fetchUserLists');
+
+describe('useUserLists', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('成功時', () => {
+    it('fetchUserListsを呼び出してデータを取得する', async () => {
+      const mockLists = [
+        createMockList({
+          id: createTestUuid(1),
+          name: 'テストリスト1',
+          public: true,
+        }),
+        createMockList({
+          id: createTestUuid(2),
+          name: 'テストリスト2',
+          public: true,
+        }),
+      ];
+
+      vi.mocked(fetchUserLists).mockResolvedValue(mockLists);
+
+      const { result } = renderHook(() => useUserLists('1'), {
+        wrapper: createProvider(),
+      });
+
+      // 初期状態: ローディング中
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.data).toBeUndefined();
+
+      // データ取得完了を待つ
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      // 成功状態を確認
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isSuccess).toBe(true);
+      expect(result.current.error).toBeNull();
+      expect(result.current.data).toEqual(mockLists);
+      expect(result.current.data).toHaveLength(2);
+
+      // fetchUserListsが正しい引数で呼ばれたことを確認
+      expect(fetchUserLists).toHaveBeenCalledWith('1');
+      expect(fetchUserLists).toHaveBeenCalledTimes(1);
+    });
+
+    it('idが空文字列の時、クエリを実行しない', () => {
+      const { result } = renderHook(() => useUserLists(''), {
+        wrapper: createProvider(),
+      });
+
+      // クエリが無効化されているため、データ取得が行われない
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(result.current.data).toBeUndefined();
+
+      // fetchUserListsが呼ばれていないことを確認
+      expect(fetchUserLists).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('エラー時', () => {
+    it('fetchUserListsがエラーをスローした場合、エラー状態になる', async () => {
+      vi.mocked(fetchUserLists).mockRejectedValue(
+        new Error('ユーザーの公開リスト一覧の取得に失敗しました'),
+      );
+
+      const { result } = renderHook(() => useUserLists('1'), {
+        wrapper: createProvider(),
+      });
+
+      // 初期状態: ローディング中
+      expect(result.current.isLoading).toBe(true);
+
+      // エラー完了を待つ
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      // エラー状態を確認
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.data).toBeUndefined();
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error?.message).toBe('ユーザーの公開リスト一覧の取得に失敗しました');
+    });
+  });
+
+  describe('React Queryの動作', () => {
+    it('正しいqueryKeyを使用する', async () => {
+      vi.mocked(fetchUserLists).mockResolvedValue([]);
+
+      const { result } = renderHook(() => useUserLists('42'), {
+        wrapper: createProvider(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      // fetchUserListsが正しいidで呼ばれたことを確認
+      expect(fetchUserLists).toHaveBeenCalledWith('42');
+    });
+  });
+});

--- a/frontend/src/app/(protected)/users/_hooks/useUserLists.test.tsx
+++ b/frontend/src/app/(protected)/users/_hooks/useUserLists.test.tsx
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { createProvider, createTestUuid } from '@/test/helpers';
-import { createMockList } from '@/test/factories';
 import { useUserLists } from './useUserLists';
 import { fetchUserLists } from '@/app/(protected)/users/_lib/fetchUserLists';
+import { List } from '@/schemas/list';
 
 // fetchUserListsをモック化
 vi.mock('@/app/(protected)/users/_lib/fetchUserLists');
@@ -15,17 +15,27 @@ describe('useUserLists', () => {
 
   describe('成功時', () => {
     it('fetchUserListsを呼び出してデータを取得する', async () => {
-      const mockLists = [
-        createMockList({
+      const mockLists: List[] = [
+        {
           id: createTestUuid(1),
           name: 'テストリスト1',
+          description: 'テスト説明1',
+          user_id: 1,
           public: true,
-        }),
-        createMockList({
+          books_count: 3,
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+        },
+        {
           id: createTestUuid(2),
           name: 'テストリスト2',
+          description: 'テスト説明2',
+          user_id: 1,
           public: true,
-        }),
+          books_count: 5,
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+        },
       ];
 
       vi.mocked(fetchUserLists).mockResolvedValue(mockLists);

--- a/frontend/src/app/(protected)/users/_hooks/useUserLists.ts
+++ b/frontend/src/app/(protected)/users/_hooks/useUserLists.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '@/constants/queryKeys';
+import { fetchUserLists } from '@/app/(protected)/users/_lib/fetchUserLists';
+
+export function useUserLists(id: string) {
+  return useQuery({
+    queryKey: queryKeys.users.lists(id),
+    queryFn: () => fetchUserLists(id),
+    enabled: !!id,
+  });
+}

--- a/frontend/src/app/(protected)/users/_lib/fetchUser.test.ts
+++ b/frontend/src/app/(protected)/users/_lib/fetchUser.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMockUserWithStats } from '@/test/factories';
+import { fetchUser } from './fetchUser';
+
+describe('fetchUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('成功時', () => {
+    it('ユーザー情報と統計を正しく取得できる', async () => {
+      const mockApiResponse = createMockUserWithStats({
+        id: 1,
+        name: 'テストユーザー',
+        stats: {
+          public_books: 10,
+          public_lists: 5,
+        },
+      });
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => mockApiResponse,
+        }),
+      );
+
+      const result = await fetchUser('1');
+
+      expect(result.id).toBe(1);
+      expect(result.name).toBe('テストユーザー');
+      expect(result.stats.public_books).toBe(10);
+      expect(result.stats.public_lists).toBe(5);
+
+      expect(fetch).toHaveBeenCalledWith('/api/users/1');
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('異なるIDで正しくリクエストできる', async () => {
+      const mockApiResponse = createMockUserWithStats({ id: 42, name: '別のユーザー' });
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => mockApiResponse,
+        }),
+      );
+
+      const result = await fetchUser('42');
+
+      expect(result.id).toBe(42);
+      expect(result.name).toBe('別のユーザー');
+      expect(fetch).toHaveBeenCalledWith('/api/users/42');
+    });
+  });
+
+  describe('エラー時', () => {
+    it('APIエラー時にエラーをスローする', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          json: async () => ({ error: 'ユーザー情報の取得に失敗しました' }),
+        }),
+      );
+
+      await expect(fetchUser('1')).rejects.toThrow('ユーザー情報の取得に失敗しました');
+    });
+
+    it('エラーメッセージがない場合、デフォルトメッセージを使用する', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          json: async () => ({}),
+        }),
+      );
+
+      await expect(fetchUser('1')).rejects.toThrow('ユーザー情報の取得に失敗しました');
+    });
+
+    it('ネットワークエラー時にエラーをスローする', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
+
+      await expect(fetchUser('1')).rejects.toThrow('Network error');
+    });
+  });
+
+  describe('Zodバリデーション', () => {
+    it('不正なデータ形式の場合、Zodエラーをスローする', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ invalid: 'data' }),
+        }),
+      );
+
+      await expect(fetchUser('1')).rejects.toThrow();
+    });
+
+    it('statsが欠落している場合、Zodエラーをスローする', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({
+            id: 1,
+            supabase_uid: '1',
+            name: 'テストユーザー',
+            avatar_url: null,
+            created_at: '2025-01-01T00:00:00Z',
+            updated_at: '2025-01-01T00:00:00Z',
+          }),
+        }),
+      );
+
+      await expect(fetchUser('1')).rejects.toThrow();
+    });
+  });
+});

--- a/frontend/src/app/(protected)/users/_lib/fetchUser.ts
+++ b/frontend/src/app/(protected)/users/_lib/fetchUser.ts
@@ -1,0 +1,17 @@
+import { userWithStatsSchema, type UserWithStats } from '@/app/(protected)/users/_types';
+
+/**
+ * ユーザー情報と統計を取得する
+ * クライアントコンポーネント（useQuery）で使用
+ */
+export async function fetchUser(id: string): Promise<UserWithStats> {
+  const response = await fetch(`/api/users/${id}`);
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.error || 'ユーザー情報の取得に失敗しました');
+  }
+
+  const data = await response.json();
+  return userWithStatsSchema.parse(data);
+}

--- a/frontend/src/app/(protected)/users/_lib/fetchUserBooks.test.ts
+++ b/frontend/src/app/(protected)/users/_lib/fetchUserBooks.test.ts
@@ -84,9 +84,7 @@ describe('fetchUserBooks', () => {
         }),
       );
 
-      await expect(fetchUserBooks('1')).rejects.toThrow(
-        'ユーザーの公開本一覧の取得に失敗しました',
-      );
+      await expect(fetchUserBooks('1')).rejects.toThrow('ユーザーの公開本一覧の取得に失敗しました');
     });
 
     it('エラーメッセージがない場合、デフォルトメッセージを使用する', async () => {
@@ -98,9 +96,7 @@ describe('fetchUserBooks', () => {
         }),
       );
 
-      await expect(fetchUserBooks('1')).rejects.toThrow(
-        'ユーザーの公開本一覧の取得に失敗しました',
-      );
+      await expect(fetchUserBooks('1')).rejects.toThrow('ユーザーの公開本一覧の取得に失敗しました');
     });
 
     it('ネットワークエラー時にエラーをスローする', async () => {

--- a/frontend/src/app/(protected)/users/_lib/fetchUserBooks.test.ts
+++ b/frontend/src/app/(protected)/users/_lib/fetchUserBooks.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMockBook } from '@/test/factories';
+import { createTestUuid } from '@/test/helpers';
+import { fetchUserBooks } from './fetchUserBooks';
+
+describe('fetchUserBooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('成功時', () => {
+    it('ユーザーの公開本一覧を正しく取得できる', async () => {
+      const mockApiResponse = [
+        createMockBook({
+          id: createTestUuid(1),
+          title: 'テスト本1',
+          public: true,
+        }),
+        createMockBook({
+          id: createTestUuid(2),
+          title: 'テスト本2',
+          public: true,
+        }),
+      ];
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => mockApiResponse,
+        }),
+      );
+
+      const result = await fetchUserBooks('1');
+
+      expect(result).toHaveLength(2);
+      expect(result[0].title).toBe('テスト本1');
+      expect(result[1].title).toBe('テスト本2');
+
+      expect(fetch).toHaveBeenCalledWith('/api/users/1/books');
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('空配列が返ってきた場合、空配列を返す', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => [],
+        }),
+      );
+
+      const result = await fetchUserBooks('1');
+
+      expect(result).toEqual([]);
+      expect(fetch).toHaveBeenCalledWith('/api/users/1/books');
+    });
+
+    it('異なるIDで正しくリクエストできる', async () => {
+      const mockApiResponse = [createMockBook({ id: createTestUuid(1) })];
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => mockApiResponse,
+        }),
+      );
+
+      const result = await fetchUserBooks('42');
+
+      expect(result).toHaveLength(1);
+      expect(fetch).toHaveBeenCalledWith('/api/users/42/books');
+    });
+  });
+
+  describe('エラー時', () => {
+    it('APIエラー時にエラーをスローする', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          json: async () => ({ error: 'ユーザーの公開本一覧の取得に失敗しました' }),
+        }),
+      );
+
+      await expect(fetchUserBooks('1')).rejects.toThrow(
+        'ユーザーの公開本一覧の取得に失敗しました',
+      );
+    });
+
+    it('エラーメッセージがない場合、デフォルトメッセージを使用する', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          json: async () => ({}),
+        }),
+      );
+
+      await expect(fetchUserBooks('1')).rejects.toThrow(
+        'ユーザーの公開本一覧の取得に失敗しました',
+      );
+    });
+
+    it('ネットワークエラー時にエラーをスローする', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
+
+      await expect(fetchUserBooks('1')).rejects.toThrow('Network error');
+    });
+  });
+
+  describe('Zodバリデーション', () => {
+    it('不正なデータ形式の場合、Zodエラーをスローする', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => [{ invalid: 'data' }],
+        }),
+      );
+
+      await expect(fetchUserBooks('1')).rejects.toThrow();
+    });
+  });
+});

--- a/frontend/src/app/(protected)/users/_lib/fetchUserBooks.ts
+++ b/frontend/src/app/(protected)/users/_lib/fetchUserBooks.ts
@@ -1,5 +1,4 @@
 import { bookSchema, type Book } from '@/schemas/book';
-import { z } from 'zod';
 
 /**
  * ユーザーの公開本一覧を取得する
@@ -14,5 +13,5 @@ export async function fetchUserBooks(id: string): Promise<Book[]> {
   }
 
   const data = await response.json();
-  return z.array(bookSchema).parse(data);
+  return bookSchema.array().parse(data);
 }

--- a/frontend/src/app/(protected)/users/_lib/fetchUserBooks.ts
+++ b/frontend/src/app/(protected)/users/_lib/fetchUserBooks.ts
@@ -1,0 +1,18 @@
+import { bookSchema, type Book } from '@/schemas/book';
+import { z } from 'zod';
+
+/**
+ * ユーザーの公開本一覧を取得する
+ * クライアントコンポーネント（useQuery）で使用
+ */
+export async function fetchUserBooks(id: string): Promise<Book[]> {
+  const response = await fetch(`/api/users/${id}/books`);
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.error || 'ユーザーの公開本一覧の取得に失敗しました');
+  }
+
+  const data = await response.json();
+  return z.array(bookSchema).parse(data);
+}

--- a/frontend/src/app/(protected)/users/_lib/fetchUserLists.test.ts
+++ b/frontend/src/app/(protected)/users/_lib/fetchUserLists.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMockList } from '@/test/factories';
+import { createTestUuid } from '@/test/helpers';
+import { fetchUserLists } from './fetchUserLists';
+
+describe('fetchUserLists', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('成功時', () => {
+    it('ユーザーの公開リスト一覧を正しく取得できる', async () => {
+      const mockApiResponse = [
+        createMockList({
+          id: createTestUuid(1),
+          name: 'テストリスト1',
+          public: true,
+        }),
+        createMockList({
+          id: createTestUuid(2),
+          name: 'テストリスト2',
+          public: true,
+        }),
+      ];
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => mockApiResponse,
+        }),
+      );
+
+      const result = await fetchUserLists('1');
+
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe('テストリスト1');
+      expect(result[1].name).toBe('テストリスト2');
+
+      expect(fetch).toHaveBeenCalledWith('/api/users/1/lists');
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('空配列が返ってきた場合、空配列を返す', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => [],
+        }),
+      );
+
+      const result = await fetchUserLists('1');
+
+      expect(result).toEqual([]);
+      expect(fetch).toHaveBeenCalledWith('/api/users/1/lists');
+    });
+
+    it('異なるIDで正しくリクエストできる', async () => {
+      const mockApiResponse = [createMockList({ id: createTestUuid(1) })];
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => mockApiResponse,
+        }),
+      );
+
+      const result = await fetchUserLists('42');
+
+      expect(result).toHaveLength(1);
+      expect(fetch).toHaveBeenCalledWith('/api/users/42/lists');
+    });
+  });
+
+  describe('エラー時', () => {
+    it('APIエラー時にエラーをスローする', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          json: async () => ({ error: 'ユーザーの公開リスト一覧の取得に失敗しました' }),
+        }),
+      );
+
+      await expect(fetchUserLists('1')).rejects.toThrow(
+        'ユーザーの公開リスト一覧の取得に失敗しました',
+      );
+    });
+
+    it('エラーメッセージがない場合、デフォルトメッセージを使用する', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          json: async () => ({}),
+        }),
+      );
+
+      await expect(fetchUserLists('1')).rejects.toThrow(
+        'ユーザーの公開リスト一覧の取得に失敗しました',
+      );
+    });
+
+    it('ネットワークエラー時にエラーをスローする', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
+
+      await expect(fetchUserLists('1')).rejects.toThrow('Network error');
+    });
+  });
+
+  describe('Zodバリデーション', () => {
+    it('不正なデータ形式の場合、Zodエラーをスローする', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => [{ invalid: 'data' }],
+        }),
+      );
+
+      await expect(fetchUserLists('1')).rejects.toThrow();
+    });
+  });
+});

--- a/frontend/src/app/(protected)/users/_lib/fetchUserLists.test.ts
+++ b/frontend/src/app/(protected)/users/_lib/fetchUserLists.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createMockList } from '@/test/factories';
 import { createTestUuid } from '@/test/helpers';
 import { fetchUserLists } from './fetchUserLists';
 
@@ -11,16 +10,26 @@ describe('fetchUserLists', () => {
   describe('成功時', () => {
     it('ユーザーの公開リスト一覧を正しく取得できる', async () => {
       const mockApiResponse = [
-        createMockList({
+        {
           id: createTestUuid(1),
           name: 'テストリスト1',
+          description: 'テスト説明1',
+          user_id: 1,
           public: true,
-        }),
-        createMockList({
+          books_count: 3,
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+        },
+        {
           id: createTestUuid(2),
           name: 'テストリスト2',
+          description: 'テスト説明2',
+          user_id: 1,
           public: true,
-        }),
+          books_count: 5,
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+        },
       ];
 
       vi.stubGlobal(
@@ -57,7 +66,18 @@ describe('fetchUserLists', () => {
     });
 
     it('異なるIDで正しくリクエストできる', async () => {
-      const mockApiResponse = [createMockList({ id: createTestUuid(1) })];
+      const mockApiResponse = [
+        {
+          id: createTestUuid(1),
+          name: 'テストリスト',
+          description: 'テスト説明',
+          user_id: 42,
+          public: true,
+          books_count: 0,
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+        },
+      ];
 
       vi.stubGlobal(
         'fetch',

--- a/frontend/src/app/(protected)/users/_lib/fetchUserLists.ts
+++ b/frontend/src/app/(protected)/users/_lib/fetchUserLists.ts
@@ -1,0 +1,18 @@
+import { listDetailSchema, type ListDetail } from '@/schemas/list';
+import { z } from 'zod';
+
+/**
+ * ユーザーの公開リスト一覧を取得する
+ * クライアントコンポーネント（useQuery）で使用
+ */
+export async function fetchUserLists(id: string): Promise<ListDetail[]> {
+  const response = await fetch(`/api/users/${id}/lists`);
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.error || 'ユーザーの公開リスト一覧の取得に失敗しました');
+  }
+
+  const data = await response.json();
+  return z.array(listDetailSchema).parse(data);
+}

--- a/frontend/src/app/(protected)/users/_lib/fetchUserLists.ts
+++ b/frontend/src/app/(protected)/users/_lib/fetchUserLists.ts
@@ -1,11 +1,10 @@
-import { listDetailSchema, type ListDetail } from '@/schemas/list';
-import { z } from 'zod';
+import { listSchema, type List } from '@/schemas/list';
 
 /**
  * ユーザーの公開リスト一覧を取得する
  * クライアントコンポーネント（useQuery）で使用
  */
-export async function fetchUserLists(id: string): Promise<ListDetail[]> {
+export async function fetchUserLists(id: string): Promise<List[]> {
   const response = await fetch(`/api/users/${id}/lists`);
 
   if (!response.ok) {
@@ -14,5 +13,5 @@ export async function fetchUserLists(id: string): Promise<ListDetail[]> {
   }
 
   const data = await response.json();
-  return z.array(listDetailSchema).parse(data);
+  return listSchema.array().parse(data);
 }

--- a/frontend/src/app/(protected)/users/_types/index.ts
+++ b/frontend/src/app/(protected)/users/_types/index.ts
@@ -1,0 +1,8 @@
+export {
+  type User,
+  type UserStats,
+  type UserWithStats,
+  userSchema,
+  userStatsSchema,
+  userWithStatsSchema,
+} from '@/schemas/user';

--- a/frontend/src/app/api/users/[id]/books/route.ts
+++ b/frontend/src/app/api/users/[id]/books/route.ts
@@ -1,0 +1,22 @@
+import { authenticatedRequest } from '@/supabase/dal';
+import { bookSchema } from '@/schemas/book';
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+// GET - ユーザーの公開本一覧取得
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const data = await authenticatedRequest(`/users/${id}/books`);
+    const books = z.array(bookSchema).parse(data);
+    return NextResponse.json(books);
+  } catch (error) {
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json({ error: '不明なエラーが発生しました' }, { status: 500 });
+  }
+}

--- a/frontend/src/app/api/users/[id]/books/route.ts
+++ b/frontend/src/app/api/users/[id]/books/route.ts
@@ -4,10 +4,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 
 // GET - ユーザーの公開本一覧取得
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
     const data = await authenticatedRequest(`/users/${id}/books`);

--- a/frontend/src/app/api/users/[id]/lists/route.ts
+++ b/frontend/src/app/api/users/[id]/lists/route.ts
@@ -1,17 +1,14 @@
 import { authenticatedRequest } from '@/supabase/dal';
-import { listDetailSchema } from '@/schemas/list';
+import { listSchema } from '@/schemas/list';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 
 // GET - ユーザーの公開リスト一覧取得
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
     const data = await authenticatedRequest(`/users/${id}/lists`);
-    const lists = z.array(listDetailSchema).parse(data);
+    const lists = z.array(listSchema).parse(data);
     return NextResponse.json(lists);
   } catch (error) {
     if (error instanceof Error) {

--- a/frontend/src/app/api/users/[id]/lists/route.ts
+++ b/frontend/src/app/api/users/[id]/lists/route.ts
@@ -1,0 +1,22 @@
+import { authenticatedRequest } from '@/supabase/dal';
+import { listDetailSchema } from '@/schemas/list';
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+// GET - ユーザーの公開リスト一覧取得
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const data = await authenticatedRequest(`/users/${id}/lists`);
+    const lists = z.array(listDetailSchema).parse(data);
+    return NextResponse.json(lists);
+  } catch (error) {
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json({ error: '不明なエラーが発生しました' }, { status: 500 });
+  }
+}

--- a/frontend/src/app/api/users/[id]/route.ts
+++ b/frontend/src/app/api/users/[id]/route.ts
@@ -3,10 +3,7 @@ import { userWithStatsSchema } from '@/schemas/user';
 import { NextRequest, NextResponse } from 'next/server';
 
 // GET - ユーザー情報取得
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
     const data = await authenticatedRequest(`/users/${id}`);

--- a/frontend/src/app/api/users/[id]/route.ts
+++ b/frontend/src/app/api/users/[id]/route.ts
@@ -1,0 +1,21 @@
+import { authenticatedRequest } from '@/supabase/dal';
+import { userWithStatsSchema } from '@/schemas/user';
+import { NextRequest, NextResponse } from 'next/server';
+
+// GET - ユーザー情報取得
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const data = await authenticatedRequest(`/users/${id}`);
+    const user = userWithStatsSchema.parse(data);
+    return NextResponse.json(user);
+  } catch (error) {
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json({ error: '不明なエラーが発生しました' }, { status: 500 });
+  }
+}

--- a/frontend/src/components/details/DetailContainer.tsx
+++ b/frontend/src/components/details/DetailContainer.tsx
@@ -2,7 +2,7 @@ import Breadcrumb from '@/components/layout/Breadcrumb';
 import { BreadcrumbItem } from '@/constants/breadcrumbs';
 
 interface DetailContainerProps {
-  breadcrumbItems: BreadcrumbItem[];
+  breadcrumbItems?: BreadcrumbItem[];
   children: React.ReactNode;
 }
 
@@ -10,7 +10,7 @@ export default function DetailContainer({ breadcrumbItems, children }: DetailCon
   return (
     <div className="flex flex-col gap-8">
       {/* パンくずリスト */}
-      <Breadcrumb items={breadcrumbItems} />
+      {breadcrumbItems && <Breadcrumb items={breadcrumbItems} />}
 
       {children}
     </div>

--- a/frontend/src/components/details/DetailOwner.test.tsx
+++ b/frontend/src/components/details/DetailOwner.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import DetailOwner from './DetailOwner';
+
+describe('DetailOwner', () => {
+  it('ユーザー名が表示される', () => {
+    render(<DetailOwner userId={1} name="テストユーザー" />);
+
+    expect(screen.getByText('テストユーザーさんのリスト'));
+  });
+
+  it('渡された userId を使用したリンクが設定されている', () => {
+    render(<DetailOwner userId={1} name="テストユーザー" />);
+
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/users/1');
+  });
+});

--- a/frontend/src/components/details/DetailOwner.tsx
+++ b/frontend/src/components/details/DetailOwner.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+
+interface DetailOwnerProps {
+  userId: number;
+  name: string;
+}
+
+export default function DetailOwner({ userId, name }: DetailOwnerProps) {
+  return (
+    <div className="mb-4">
+      <Link
+        href={`/users/${userId}`}
+        className="text-sm text-slate-600 hover:text-primary transition-colors"
+      >
+        {name}さんのリスト
+      </Link>
+    </div>
+  );
+}

--- a/frontend/src/components/details/index.ts
+++ b/frontend/src/components/details/index.ts
@@ -3,3 +3,4 @@ export { default as DetailCard } from './DetailCard';
 export { default as DetailHeader } from './DetailHeader';
 export { default as DetailDescription } from './DetailDescription';
 export { default as DetailMetadata } from './DetailMetadata';
+export { default as DetailOwner } from './DetailOwner';

--- a/frontend/src/components/feedback/index.ts
+++ b/frontend/src/components/feedback/index.ts
@@ -1,0 +1,3 @@
+export { default as EmptyState } from './EmptyState';
+export { default as ErrorMessage } from './ErrorMessage';
+export { default as LoadingState } from './LoadingState';

--- a/frontend/src/constants/queryKeys.ts
+++ b/frontend/src/constants/queryKeys.ts
@@ -26,4 +26,9 @@ export const queryKeys = {
   top: {
     all: ['top'] as const, // トップページデータ取得用
   },
+  users: {
+    detail: (id: string) => ['users', 'detail', id] as const, // ユーザー詳細取得用
+    books: (id: string) => ['users', 'books', id] as const, // ユーザーの公開本一覧取得用
+    lists: (id: string) => ['users', 'lists', id] as const, // ユーザーの公開リスト一覧取得用
+  },
 } as const;

--- a/frontend/src/schemas/list.ts
+++ b/frontend/src/schemas/list.ts
@@ -33,6 +33,10 @@ export const listDetailSchema = listSchema.extend({
     }),
   ),
   list_books: z.array(listBookSchema),
+  user: z.object({
+    id: z.number(),
+    name: z.string(),
+  }),
 });
 
 // Listのバリデーションスキーマ(フォーム用)

--- a/frontend/src/schemas/user.ts
+++ b/frontend/src/schemas/user.ts
@@ -17,6 +17,17 @@ export const userSchema = z.object({
   }),
 });
 
+// ユーザー統計情報のスキーマ
+export const userStatsSchema = z.object({
+  public_books: z.number(),
+  public_lists: z.number(),
+});
+
+// 統計情報を含むユーザー情報のスキーマ
+export const userWithStatsSchema = userSchema.extend({
+  stats: userStatsSchema,
+});
+
 // Userのバリデーションスキーマ(フォーム用)
 export const userFormSchema = z.object({
   name: z
@@ -28,4 +39,6 @@ export const userFormSchema = z.object({
 });
 
 export type User = z.infer<typeof userSchema>;
+export type UserStats = z.infer<typeof userStatsSchema>;
+export type UserWithStats = z.infer<typeof userWithStatsSchema>;
 export type UserFormData = z.infer<typeof userFormSchema>;

--- a/frontend/src/test/factories/index.ts
+++ b/frontend/src/test/factories/index.ts
@@ -3,5 +3,5 @@ export { createMockCategory } from './category';
 export { createMockList } from './list';
 export { createMockListBook } from './listBook';
 export { createMockCard } from './card';
-export { createMockUser } from './user';
+export { createMockUser, createMockUserWithStats } from './user';
 export { createMockTopPageData } from './topPage';

--- a/frontend/src/test/factories/list.ts
+++ b/frontend/src/test/factories/list.ts
@@ -17,5 +17,9 @@ export const createMockList = (overrides?: Partial<ListDetail>): ListDetail => (
   updated_at: '2025-01-01T00:00:00Z',
   books: [],
   list_books: [],
+  user: {
+    id: 1,
+    name: 'テストユーザー',
+  },
   ...overrides,
 });

--- a/frontend/src/test/factories/user.ts
+++ b/frontend/src/test/factories/user.ts
@@ -1,4 +1,4 @@
-import { User } from '@/schemas/user';
+import { User, UserWithStats } from '@/schemas/user';
 
 /**
  * テスト用のUserオブジェクトを作成するファクトリー関数
@@ -12,5 +12,24 @@ export const createMockUser = (overrides?: Partial<User>): User => ({
   avatar_url: null,
   created_at: '2025-01-01T00:00:00Z',
   updated_at: '2025-01-01T00:00:00Z',
+  ...overrides,
+});
+
+/**
+ * テスト用のUserWithStatsオブジェクトを作成するファクトリー関数
+ * @param overrides - デフォルト値を上書きするプロパティ
+ * @returns UserWithStats型のモックオブジェクト
+ */
+export const createMockUserWithStats = (overrides?: Partial<UserWithStats>): UserWithStats => ({
+  id: 1,
+  supabase_uid: '1',
+  name: 'テストユーザー',
+  avatar_url: null,
+  created_at: '2025-01-01T00:00:00Z',
+  updated_at: '2025-01-01T00:00:00Z',
+  stats: {
+    public_books: 5,
+    public_lists: 2,
+  },
   ...overrides,
 });


### PR DESCRIPTION
## 概要
ユーザープロフィールページを実装し、リスト・書籍詳細ページの権限管理とセキュリティを強化しました。

## 詳細
### バックエンド
- ユーザープロフィールAPI（統計情報含む）を実装
- ユーザーの公開書籍・リスト一覧APIを実装
- リスト詳細APIに権限チェックと公開書籍フィルタリングを追加
- リストに登録されている公開書籍数のカウント機能を追加

### フロントエンド
- ユーザープロフィールページを実装（GitHub風デザイン）
- ユーザーの公開書籍・リスト一覧表示機能を実装
- リスト詳細ページに所有者表示機能を追加
- 所有者のみに編集・削除ボタンを表示するように変更
- 他ユーザーの書籍詳細ページへのリンクを非表示に
- DetailOwnerコンポーネントを追加（リスト所有者表示）

### テスト
- バックエンドAPIのテストを追加
- フロントエンドの型定義・スキーマテストを追加
- データ取得関数とカスタムフックのテストを追加
- View・Clientコンポーネントのテストを追加

## 関連イシュー
#141