### PR TITLE
ユーザー検索機能を実装

### DIFF
--- a/backend/app/controllers/api/users_controller.rb
+++ b/backend/app/controllers/api/users_controller.rb
@@ -1,6 +1,23 @@
 class Api::UsersController < Api::ApplicationController
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
+  def index
+    query = params[:q].to_s.strip
+
+    if query.blank?
+      render json: []
+      return
+    end
+
+    # 現在のユーザーを除外してユーザー名で部分一致検索
+    users = User.where('name ILIKE ?', "%#{query}%")
+                .where.not(id: current_user.id)
+                .limit(20)
+                .order(:name)
+
+    render json: users
+  end
+
   def show
     user = User.find(params[:id])
     render json: user.as_json.merge(stats: user.stats)

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
     resources :tags, only: %i[index create update destroy]
     resources :statuses, only: %i[index create update destroy]
     resource :profile, only: %i[show update]
-    resources :users, only: %i[show] do
+    resources :users, only: %i[index show] do
       member do
         get :books
         get :lists

--- a/frontend/src/app/(protected)/users/_types/index.ts
+++ b/frontend/src/app/(protected)/users/_types/index.ts
@@ -2,7 +2,9 @@ export {
   type User,
   type UserStats,
   type UserWithStats,
+  type UserSearchResult,
   userSchema,
   userStatsSchema,
   userWithStatsSchema,
+  userSearchResultSchema,
 } from '@/schemas/user';

--- a/frontend/src/app/(protected)/users/search/_components/UserSearchInput.test.tsx
+++ b/frontend/src/app/(protected)/users/search/_components/UserSearchInput.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import UserSearchInput from './UserSearchInput';
+
+describe('UserSearchInput', () => {
+  describe('レンダリング', () => {
+    it('入力欄が表示される', () => {
+      const mockSetQuery = vi.fn();
+      render(<UserSearchInput query="" setQuery={mockSetQuery} isLoading={false} />);
+
+      const input = screen.getByPlaceholderText('ユーザー名で検索');
+      expect(input).toBeInTheDocument();
+    });
+
+    it('propsで渡されたqueryが入力欄に表示される', () => {
+      const mockSetQuery = vi.fn();
+      render(<UserSearchInput query="test query" setQuery={mockSetQuery} isLoading={false} />);
+
+      const input = screen.getByPlaceholderText('ユーザー名で検索');
+      expect(input).toHaveValue('test query');
+    });
+  });
+
+  describe('ユーザー操作', () => {
+    it('テキストを入力するとsetQueryが呼ばれる', async () => {
+      const user = userEvent.setup();
+      const mockSetQuery = vi.fn();
+      render(<UserSearchInput query="" setQuery={mockSetQuery} isLoading={false} />);
+
+      const input = screen.getByPlaceholderText('ユーザー名で検索');
+      await user.type(input, 'test');
+
+      // 各文字ごとにsetQueryが呼ばれる
+      expect(mockSetQuery).toHaveBeenCalledTimes(4);
+      expect(mockSetQuery).toHaveBeenNthCalledWith(1, 't');
+      expect(mockSetQuery).toHaveBeenNthCalledWith(2, 'e');
+      expect(mockSetQuery).toHaveBeenNthCalledWith(3, 's');
+      expect(mockSetQuery).toHaveBeenNthCalledWith(4, 't');
+    });
+
+    it('入力欄をクリアするとsetQueryが空文字で呼ばれる', async () => {
+      const user = userEvent.setup();
+      const mockSetQuery = vi.fn();
+      render(<UserSearchInput query="test" setQuery={mockSetQuery} isLoading={false} />);
+
+      const input = screen.getByPlaceholderText('ユーザー名で検索');
+      await user.clear(input);
+
+      expect(mockSetQuery).toHaveBeenCalledWith('');
+    });
+  });
+
+  describe('ローディング状態', () => {
+    it('isLoading が false の場合、スピナーが表示されない', () => {
+      const mockSetQuery = vi.fn();
+      render(<UserSearchInput query="" setQuery={mockSetQuery} isLoading={false} />);
+
+      expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+    });
+
+    it('isLoading が true の場合、スピナーが表示される', () => {
+      const mockSetQuery = vi.fn();
+      render(<UserSearchInput query="test" setQuery={mockSetQuery} isLoading={true} />);
+
+      expect(screen.getByTestId('spinner')).toBeInTheDocument();
+    });
+  });
+
+  describe('アクセシビリティ', () => {
+    it('入力欄がtext typeである', () => {
+      const mockSetQuery = vi.fn();
+      render(<UserSearchInput query="" setQuery={mockSetQuery} isLoading={false} />);
+
+      const input = screen.getByPlaceholderText('ユーザー名で検索');
+      expect(input).toHaveAttribute('type', 'text');
+    });
+
+    it('プレースホルダーが適切に設定されている', () => {
+      const mockSetQuery = vi.fn();
+      render(<UserSearchInput query="" setQuery={mockSetQuery} isLoading={false} />);
+
+      const input = screen.getByPlaceholderText('ユーザー名で検索');
+      expect(input).toHaveAttribute('placeholder', 'ユーザー名で検索');
+    });
+  });
+});

--- a/frontend/src/app/(protected)/users/search/_components/UserSearchInput.tsx
+++ b/frontend/src/app/(protected)/users/search/_components/UserSearchInput.tsx
@@ -1,0 +1,27 @@
+interface UserSearchInputProps {
+  query: string;
+  setQuery: (query: string) => void;
+  isLoading: boolean;
+}
+
+export default function UserSearchInput({ query, setQuery, isLoading }: UserSearchInputProps) {
+  return (
+    <div className="relative mb-6">
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="ユーザー名で検索"
+        className="w-full px-4 py-3 pr-10 border border-gray-300 bg-white rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+      />
+      {isLoading && (
+        <div className="absolute right-3 top-1/2 -translate-y-1/2">
+          <div
+            className="animate-spin rounded-full h-5 w-5 border-b-2 border-blue-600"
+            data-testid="spinner"
+          ></div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/(protected)/users/search/_components/UserSearchResults.test.tsx
+++ b/frontend/src/app/(protected)/users/search/_components/UserSearchResults.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import UserSearchResults from './UserSearchResults';
+import { createMockUser } from '@/test/factories';
+
+describe('UserSearchResults', () => {
+  describe('表示条件分岐', () => {
+    it('query が 0 文字の場合、何も表示されない', () => {
+      const { container } = render(
+        <UserSearchResults query="" suggestions={[]} isLoading={false} />,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('query が 2 文字以上で isLoading が true の場合、「検索中...」と表示される', () => {
+      render(<UserSearchResults query="test" suggestions={[]} isLoading={true} />);
+
+      expect(screen.getByText('検索中...')).toBeInTheDocument();
+    });
+
+    it('query が 2 文字以上で検索結果がない場合、「一致するユーザーが見つかりませんでした」と表示される', () => {
+      render(<UserSearchResults query="test" suggestions={[]} isLoading={false} />);
+
+      expect(screen.getByText(/一致するユーザーが見つかりませんでした/)).toBeInTheDocument();
+      expect(screen.getByText(/test/)).toBeInTheDocument();
+    });
+  });
+
+  describe('検索結果の表示', () => {
+    const mockUsers = [
+      createMockUser({ id: 1, name: 'ユーザーA' }),
+      createMockUser({ id: 2, name: 'ユーザーB' }),
+      createMockUser({ id: 3, name: 'ユーザーC' }),
+    ];
+
+    it('検索結果がある場合、件数が表示される', () => {
+      render(<UserSearchResults query="user" suggestions={mockUsers} isLoading={false} />);
+
+      expect(screen.getByText('3件のユーザーが見つかりました')).toBeInTheDocument();
+    });
+
+    it('検索結果がある場合、すべてのユーザー名が表示される', () => {
+      render(<UserSearchResults query="user" suggestions={mockUsers} isLoading={false} />);
+
+      expect(screen.getByText('ユーザーA')).toBeInTheDocument();
+      expect(screen.getByText('ユーザーB')).toBeInTheDocument();
+      expect(screen.getByText('ユーザーC')).toBeInTheDocument();
+    });
+
+    it('各ユーザーカードに正しいリンクが設定されている', () => {
+      render(<UserSearchResults query="user" suggestions={mockUsers} isLoading={false} />);
+
+      const links = screen.getAllByRole('link');
+      expect(links).toHaveLength(3);
+      expect(links[0]).toHaveAttribute('href', '/users/1');
+      expect(links[1]).toHaveAttribute('href', '/users/2');
+      expect(links[2]).toHaveAttribute('href', '/users/3');
+    });
+
+    it('各ユーザーカードにアバター（頭文字）が表示される', () => {
+      render(<UserSearchResults query="user" suggestions={mockUsers} isLoading={false} />);
+
+      expect(screen.getAllByTestId('initial')).toHaveLength(3);
+      expect(screen.getAllByTestId('initial')[0]).toHaveTextContent('ユ');
+    });
+
+    it('名前の頭文字が小文字でも大文字で表示される', () => {
+      const lowerCaseUsers = [createMockUser({ id: 1, name: 'alice' })];
+      render(<UserSearchResults query="alice" suggestions={lowerCaseUsers} isLoading={false} />);
+
+      expect(screen.getByText('A')).toBeInTheDocument();
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('検索結果が1件の場合、「1件のユーザーが見つかりました」と表示される', () => {
+      const singleUser = [createMockUser({ id: 1, name: 'ユーザー' })];
+      render(<UserSearchResults query="single" suggestions={singleUser} isLoading={false} />);
+
+      expect(screen.getByText('1件のユーザーが見つかりました')).toBeInTheDocument();
+    });
+
+    it('query にトリムが必要なスペースがある場合でも正しく動作する', () => {
+      render(<UserSearchResults query="  test  " suggestions={[]} isLoading={false} />);
+
+      expect(screen.getByText(/一致するユーザーが見つかりませんでした/)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/app/(protected)/users/search/_components/UserSearchResults.tsx
+++ b/frontend/src/app/(protected)/users/search/_components/UserSearchResults.tsx
@@ -1,0 +1,66 @@
+import Link from 'next/link';
+import { UserSearchResult } from '@/app/(protected)/users/_types';
+
+interface UserSearchResultsProps {
+  query: string;
+  suggestions: UserSearchResult[];
+  isLoading: boolean;
+}
+
+export default function UserSearchResults({
+  query,
+  suggestions,
+  isLoading,
+}: UserSearchResultsProps) {
+  const trimmedQuery = query.trim();
+
+  // 2文字以上の場合のみ結果を表示
+  if (trimmedQuery.length < 2) {
+    return null;
+  }
+
+  // ローディング中
+  if (isLoading) {
+    return <div className="text-center py-8 text-gray-500">検索中...</div>;
+  }
+
+  // 検索結果がある場合
+  if (suggestions.length > 0) {
+    return (
+      <div className="space-y-2">
+        <p className="text-sm text-gray-600 mb-4">
+          {suggestions.length}件のユーザーが見つかりました
+        </p>
+        <div className="space-y-2">
+          {suggestions.map((user) => (
+            <Link
+              key={user.id}
+              href={`/users/${user.id}`}
+              className="block p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+            >
+              <div className="flex items-center gap-3">
+                {/* TODO: ユーザー画像変更機能実装後に画像を表示するように変更 */}
+                <div
+                  className="w-10 h-10 rounded-full bg-blue-500 flex items-center justify-center text-white font-medium"
+                  data-testid="initial"
+                >
+                  {user.name.charAt(0).toUpperCase()}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="font-medium text-gray-900 truncate">{user.name}</div>
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // 検索結果がない場合
+  return (
+    <div className="text-center py-8 text-gray-500">
+      「{query}」に一致するユーザーが見つかりませんでした
+    </div>
+  );
+}

--- a/frontend/src/app/(protected)/users/search/_components/index.ts
+++ b/frontend/src/app/(protected)/users/search/_components/index.ts
@@ -1,0 +1,2 @@
+export { default as UserSearchInput } from './UserSearchInput';
+export { default as UserSearchResults } from './UserSearchResults';

--- a/frontend/src/app/(protected)/users/search/_hooks/useUserSearchApi.test.ts
+++ b/frontend/src/app/(protected)/users/search/_hooks/useUserSearchApi.test.ts
@@ -1,0 +1,165 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useUserSearchApi } from './useUserSearchApi';
+import { createMockUser } from '@/test/factories';
+
+describe('useUserSearchApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('初期状態', () => {
+    it('query が空文字列であること', () => {
+      const { result } = renderHook(() => useUserSearchApi());
+      expect(result.current.query).toBe('');
+    });
+
+    it('suggestions が空配列であること', () => {
+      const { result } = renderHook(() => useUserSearchApi());
+      expect(result.current.suggestions).toEqual([]);
+    });
+
+    it('isLoading が false であること', () => {
+      const { result } = renderHook(() => useUserSearchApi());
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe('useEffect: query の変更', () => {
+    it('query が 2 文字未満の場合、suggestions が空配列になること', () => {
+      const { result } = renderHook(() => useUserSearchApi());
+
+      // 初期状態
+      expect(result.current.suggestions).toEqual([]);
+      expect(result.current.isLoading).toBe(false);
+
+      // 2 文字未満に設定
+      act(() => {
+        result.current.setQuery('a');
+      });
+
+      expect(result.current.suggestions).toEqual([]);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('query が 2 文字以上の場合、デバウンス後に検索APIが呼ばれる', async () => {
+      const mockUsers = [
+        createMockUser({ id: 1, name: 'testA' }),
+        createMockUser({ id: 2, name: 'testB' }),
+      ];
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => mockUsers,
+        }),
+      );
+      const { result } = renderHook(() => useUserSearchApi());
+
+      // 初期状態
+      expect(result.current.isLoading).toBe(false);
+
+      // 2 文字以上に設定
+      act(() => {
+        result.current.setQuery('test');
+      });
+
+      // isLoading が true になる
+      expect(result.current.isLoading).toBe(true);
+
+      // タイマーとPromiseを全て実行
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      // fetch API が呼ばれる
+      expect(fetch).toHaveBeenCalledWith('/api/users?q=test');
+
+      // suggestions が設定される
+      expect(result.current.suggestions).toEqual(mockUsers);
+
+      // isLoading が false になる
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('query が変更されたら、前のタイマーがキャンセルされる（デバウンス）', async () => {
+      const mockUsers = [
+        createMockUser({ id: 1, name: 'testA' }),
+        createMockUser({ id: 2, name: 'testB' }),
+      ];
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => mockUsers,
+        }),
+      );
+      const { result } = renderHook(() => useUserSearchApi());
+
+      // 最初のクエリを設定
+      act(() => {
+        result.current.setQuery('test');
+      });
+
+      expect(result.current.isLoading).toBe(true);
+
+      // 500ms 経過（まだデバウンス時間内）
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      // クエリを変更（前のタイマーがキャンセルされる）
+      act(() => {
+        result.current.setQuery('testA');
+      });
+
+      // さらに 500ms 経過（合計 1000ms だが、2回目のクエリからは 500ms）
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      // まだ fetch は呼ばれていない（2回目のクエリから 1000ms 経っていない）
+      expect(fetch).not.toHaveBeenCalled();
+
+      // さらに 500ms 経過（2回目のクエリから 1000ms）
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      // fetch が 'testA' で呼ばれる（'test' では呼ばれない）
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith('/api/users?q=testA');
+    });
+  });
+
+  describe('異常系: fetch API のエラー', () => {
+    it('検索エラー時は空配列が返される', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('エラーです')));
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { result } = renderHook(() => useUserSearchApi());
+
+      act(() => {
+        result.current.setQuery('test');
+      });
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(fetch).toHaveBeenCalledWith('/api/users?q=test');
+      expect(result.current.suggestions).toEqual([]);
+      expect(result.current.isLoading).toBe(false);
+      expect(consoleErrorSpy).toHaveBeenCalledWith('User search error:', expect.any(Error));
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+});

--- a/frontend/src/app/(protected)/users/search/_hooks/useUserSearchApi.ts
+++ b/frontend/src/app/(protected)/users/search/_hooks/useUserSearchApi.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { UserSearchResult } from '@/schemas/user';
+
+export function useUserSearchApi() {
+  const [query, setQuery] = useState('');
+  const [suggestions, setSuggestions] = useState<UserSearchResult[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const trimmed = query.trim();
+
+    if (trimmed.length < 2) {
+      setSuggestions([]);
+      setIsLoading(false);
+      return;
+    }
+    setIsLoading(true);
+
+    const timer = setTimeout(async () => {
+      try {
+        const response = await fetch(`/api/users?q=${encodeURIComponent(trimmed)}`);
+        if (!response.ok) {
+          throw new Error('ユーザー検索に失敗しました');
+        }
+        const data = await response.json();
+        setSuggestions(data);
+      } catch (error) {
+        console.error('User search error:', error);
+        setSuggestions([]);
+      } finally {
+        setIsLoading(false);
+      }
+    }, 1000);
+
+    return () => {
+      clearTimeout(timer);
+      setIsLoading(false);
+    };
+  }, [query]);
+
+  return {
+    query,
+    setQuery,
+    suggestions,
+    isLoading,
+  };
+}

--- a/frontend/src/app/(protected)/users/search/page.tsx
+++ b/frontend/src/app/(protected)/users/search/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { UserSearchInput, UserSearchResults } from '@/app/(protected)/users/search/_components';
+import { useUserSearchApi } from '@/app/(protected)/users/search/_hooks/useUserSearchApi';
+
+export default function UsersPage() {
+  const { query, setQuery, suggestions, isLoading } = useUserSearchApi();
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-4xl">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900 mb-2">ユーザー検索</h1>
+        <p className="text-gray-600">ユーザー名で検索して、プロフィールを閲覧できます。</p>
+      </div>
+
+      {/* 検索入力 */}
+      <UserSearchInput query={query} setQuery={setQuery} isLoading={isLoading} />
+
+      {/* 検索結果一覧 */}
+      <UserSearchResults query={query} suggestions={suggestions} isLoading={isLoading} />
+    </div>
+  );
+}

--- a/frontend/src/app/api/users/route.ts
+++ b/frontend/src/app/api/users/route.ts
@@ -1,0 +1,25 @@
+import { authenticatedRequest } from '@/supabase/dal';
+import { userSearchResultSchema } from '@/schemas/user';
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+// GET - ユーザー検索
+export async function GET(request: NextRequest) {
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const query = searchParams.get('q') || '';
+
+    if (!query.trim()) {
+      return NextResponse.json([]);
+    }
+
+    const data = await authenticatedRequest(`/users?q=${encodeURIComponent(query)}`);
+    const users = z.array(userSearchResultSchema).parse(data);
+    return NextResponse.json(users);
+  } catch (error) {
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json({ error: '不明なエラーが発生しました' }, { status: 500 });
+  }
+}

--- a/frontend/src/components/navigation/SideNav.test.tsx
+++ b/frontend/src/components/navigation/SideNav.test.tsx
@@ -86,6 +86,8 @@ describe('SideNav', () => {
     render(<SideNav />);
 
     expect(screen.getByText('ホーム')).toBeInTheDocument();
+    expect(screen.getByText('ユーザーを検索')).toBeInTheDocument();
+    expect(screen.getByText('本を検索')).toBeInTheDocument();
     expect(screen.getByText('本棚')).toBeInTheDocument();
     expect(screen.getByText('リスト')).toBeInTheDocument();
     expect(screen.getByText('カード')).toBeInTheDocument();

--- a/frontend/src/constants/navItems.ts
+++ b/frontend/src/constants/navItems.ts
@@ -1,7 +1,8 @@
-import { Home, BookOpen, ListTodo, Lightbulb, Settings, Search } from 'lucide-react';
+import { Home, BookOpen, ListTodo, Lightbulb, Settings, Search, User } from 'lucide-react';
 
 export const NAV_ITEMS = [
   { href: '/top', label: 'ホーム', icon: Home },
+  { href: '/users/search', label: 'ユーザーを検索', icon: User },
   { href: '/books/search', label: '本を検索', icon: Search },
   { href: '/books', label: '本棚', icon: BookOpen },
   { href: '/lists', label: 'リスト', icon: ListTodo },

--- a/frontend/src/schemas/user.ts
+++ b/frontend/src/schemas/user.ts
@@ -28,6 +28,13 @@ export const userWithStatsSchema = userSchema.extend({
   stats: userStatsSchema,
 });
 
+// ユーザー検索結果のスキーマ
+export const userSearchResultSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  avatar_url: z.string().nullable(),
+});
+
 // Userのバリデーションスキーマ(フォーム用)
 export const userFormSchema = z.object({
   name: z
@@ -42,3 +49,4 @@ export type User = z.infer<typeof userSchema>;
 export type UserStats = z.infer<typeof userStatsSchema>;
 export type UserWithStats = z.infer<typeof userWithStatsSchema>;
 export type UserFormData = z.infer<typeof userFormSchema>;
+export type UserSearchResult = z.infer<typeof userSearchResultSchema>;


### PR DESCRIPTION
## 概要
ユーザー名で他のユーザーを検索し、プロフィールページに遷移できる機能を実装しました。

## 詳細
### バックエンド
- GET /api/users?q=検索ワード エンドポイントを追加
- ILIKE句を使用した大文字小文字を区別しない部分一致検索
- 現在のユーザーを検索結果から除外
- 最大20件に制限してパフォーマンスを確保

### フロントエンド
- `/users/search` ページを新規作成
- ユーザー検索結果用のスキーマ定義（userSearchResultSchema）
- API Route（/api/users）を実装
- useUserSearchApi フック（1秒のデバウンス処理）
- UserSearchInput コンポーネント（検索入力欄）
- UserSearchResults コンポーネント（検索結果一覧）
- 2文字以上入力で検索開始
- ローディング状態、エラー状態、結果なし状態の表示
- 検索結果からユーザー詳細ページへの遷移

### テスト
- useUserSearchApi フックのテスト（デバウンス処理、エラーハンドリング）
- UserSearchInput コンポーネントのテスト
- UserSearchResults コンポーネントのテスト

## 関連イシュー
Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)