### PR TITLE
Aboutページの実装

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -29,7 +29,9 @@ services:
     command: bash -c "bundle exec rails db:prepare && bin/rails server -b 0.0.0.0 -p 3000"
 
   web:
-    build: ./frontend
+    build:
+      context: ./frontend
+      target: development  # 開発環境のステージを使用
     ports:
       - "3001:3001"
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,11 +1,47 @@
-FROM node:22
+# ========== ベースイメージ ==========
+FROM node:22 AS base
 
 WORKDIR /home/node/app
 
 COPY package*.json ./
+
+# ========== 開発環境（Playwrightを含む） ==========
+FROM base AS development
+
+# すべての依存関係をインストール
 RUN npm install
+
+# Playwrightをインストール（開発/テスト環境のみ）
+RUN npx playwright install chromium
+RUN npx playwright install-deps chromium
 
 COPY . .
 
 EXPOSE 3001
 CMD ["npm", "run", "dev", "--", "--hostname", "0.0.0.0", "--port", "3001"]
+
+# ========== ビルドステージ ==========
+FROM base AS builder
+
+# 本番用の依存関係を含めてインストール
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# ========== 本番環境（軽量） ==========
+FROM node:22-slim AS production
+
+WORKDIR /home/node/app
+
+# 本番用の依存関係のみインストール
+COPY package*.json ./
+RUN npm ci --production
+
+# ビルド成果物をコピー
+COPY --from=builder /home/node/app/.next ./.next
+COPY --from=builder /home/node/app/public ./public
+COPY --from=builder /home/node/app/next.config.ts ./next.config.ts
+
+EXPOSE 3001
+CMD ["npm", "start"]

--- a/frontend/e2e/about.spec.ts
+++ b/frontend/e2e/about.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * アバウトページのE2Eテスト
+ */
+import { test, expect } from '@playwright/test';
+
+// テスト用の認証情報を環境変数から取得
+const TEST_EMAIL = process.env.TEST_USER_EMAIL || 'test-user@example.com';
+const TEST_PASSWORD = process.env.TEST_USER_PASSWORD || 'password1234';
+
+test.describe('アバウトページ', () => {
+  // 各テストの前にストレージをクリアして、ログイン状態をリセット
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+  });
+
+  test('ヘッダーからアバウトページにアクセスできる', async ({ page }) => {
+    await page.goto('/');
+
+    const aboutLink = page.getByRole('link', { name: /About/i });
+    await aboutLink.click();
+
+    // ページ遷移を待って、Aboutページの見出しが表示されることを確認
+    await expect(page.getByRole('heading', { level: 1, name: /ぽんダナについて/i })).toBeVisible();
+  });
+
+  test('未ログイン状態で新規登録ページへリンクできる', async ({ page }) => {
+    await page.goto('/');
+
+    const aboutLink = page.getByRole('link', { name: /About/i });
+    await aboutLink.click();
+
+    const startLink = page.getByRole('link', { name: /今すぐ始める/i });
+    await startLink.click();
+
+    // 新規登録ページに遷移することを確認
+    await expect(page).toHaveURL(/.*register/);
+    await expect(page.getByRole('heading', { level: 2, name: /新規登録/i })).toBeVisible();
+  });
+
+  test('ログイン状態でトップページへリンクできる', async ({ page }) => {
+    await page.goto('/');
+
+    const loginLink = page.getByRole('link', { name: /ログイン/i });
+    await loginLink.click();
+
+    // ログインページに遷移したことを確認
+    await expect(page).toHaveURL(/.*login/);
+
+    const emailInput = page.getByLabel(/メールアドレス/i);
+    await emailInput.fill(TEST_EMAIL);
+
+    const passwordInput = page.getByLabel(/パスワード/i);
+    await passwordInput.fill(TEST_PASSWORD);
+
+    const loginButton = page.getByRole('button', { name: /ログイン/i });
+    await loginButton.click();
+
+    // ログイン後、トップページに遷移することを確認
+    await page.waitForURL(/.*top/, { timeout: 10000 });
+
+    const aboutLink = page.getByRole('link', { name: /About/i });
+    await aboutLink.click();
+
+    const startLink = page.getByRole('link', { name: /今すぐ始める/i });
+    await startLink.click();
+
+    // ログイン済みの場合、トップページに遷移することを確認
+    await expect(page).toHaveURL(/.*top/);
+  });
+});

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -16,6 +16,11 @@ const TEST_EMAIL = process.env.TEST_USER_EMAIL || 'test-user@example.com';
 const TEST_PASSWORD = process.env.TEST_USER_PASSWORD || 'password1234';
 
 test.describe('ログイン機能', () => {
+  // 各テストの前にストレージをクリアして、ログイン状態をリセット
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+  });
+
   test('トップページからログインページに遷移してログインできること', async ({ page }) => {
     await page.goto('/');
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -22,8 +22,8 @@ export default defineConfig({
   // テスト失敗時のリトライ回数（CI環境では2回、ローカルでは0回）
   retries: process.env.CI ? 2 : 0,
 
-  // 並列実行するワーカー数（CI環境では1、ローカルではCPU数に応じて自動）
-  workers: process.env.CI ? 1 : undefined,
+  // 並列実行するワーカー数（認証状態の干渉を防ぐため常に1）
+  workers: 1,
 
   // テスト結果のレポート形式（html = ブラウザで見やすいレポート）
   reporter: 'html',

--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -1,0 +1,65 @@
+import Link from 'next/link';
+
+export default function AboutPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-sky-50 py-16">
+      <div className="mx-auto max-w-3xl px-4">
+        <h1 className="mb-8 text-3xl font-bold text-gray-900">ぽんダナについて</h1>
+
+        <section className="mb-12 space-y-4 text-gray-700">
+          <h2 className="mb-4 text-2xl font-semibold text-gray-900">サービス概要</h2>
+          <p className="leading-relaxed">
+            技術書など難解な書籍の読書記録に特化し、
+            <strong>知識を分野ごとに棚卸し・管理</strong>するアプリです。
+          </p>
+          <p className="leading-relaxed">
+            読み終えた本の詳細なメモや感想を記録し、自身の学習進捗と習得範囲を可視化することで客観的に自分の学習を振り返れるようにします。
+          </p>
+          <p className="leading-relaxed">
+            他のエンジニアと読書リストを共有し、学習意欲の高いエンジニアの学習経路を築く手助けをします。
+          </p>
+        </section>
+
+        <section className="mb-12 space-y-4 text-gray-700">
+          <h2 className="mb-4 text-2xl font-semibold text-gray-900">主な機能</h2>
+          <ul className="list-disc space-y-2 pl-6">
+            <li>技術書の登録とカテゴリ分類</li>
+            <li>読書中の知識メモ（ナレッジカード）作成</li>
+            <li>5段階評価と詳細な感想の記録</li>
+            <li>読書リストの公開・共有</li>
+            <li>学習進捗の可視化</li>
+          </ul>
+        </section>
+
+        <section className="mb-12 space-y-4 text-gray-700">
+          <h2 className="mb-4 text-2xl font-semibold text-gray-900">こんな方におすすめ</h2>
+          <div className="space-y-4">
+            <div>
+              <h3 className="mb-2 font-semibold text-gray-900">
+                学習ルートを確立したい初学者・若手エンジニア
+              </h3>
+              <p className="leading-relaxed">
+                優れたエンジニアが何を読んで成長したかを参考に、効率的な学習ルートを見つけられます。
+              </p>
+            </div>
+            <div>
+              <h3 className="mb-2 font-semibold text-gray-900">技術書・専門書を読むエンジニア</h3>
+              <p className="leading-relaxed">
+                複雑な知識を体系的に管理し、どの技術分野の学習を終えたかを深掘りして記録できます。
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <div className="mt-12 text-center">
+          <Link
+            href="/register"
+            className="inline-block rounded-md bg-blue-600 px-6 py-3 text-white transition-colors hover:bg-blue-700"
+          >
+            今すぐ始める
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -14,6 +14,9 @@ export default function Header({ isAuthenticated }: HeaderProps) {
         </h1>
         <nav>
           <ul className="flex items-center gap-4 text-sm font-medium text-gray-600">
+            <li className="transition-colors hover:text-gray-900">
+              <Link href="/about">About</Link>
+            </li>
             {!isAuthenticated ? (
               <>
                 <li className="transition-colors hover:text-gray-900">


### PR DESCRIPTION
## 概要
アプリケーションの紹介を行うAboutページを実装しました。

## 変更内容

### 1. Aboutページの追加
- サービス概要、主な機能、おすすめユーザーのセクションを実装
- 「今すぐ始める」ボタンで新規登録ページへ導線を提供
- ヘッダーにAboutリンクを追加
- 登録・ログインページと統一されたグラデーション背景デザイン

### 2. Dockerマルチステージビルドの導入
- 開発環境: Playwrightを含む完全な環境 (3.85GB)
- 本番環境: 軽量化されたイメージ (1.11GB, 71%削減)
- コンテナ再起動時にPlaywrightを再インストールする必要がなくなった

### 3. E2Eテストの改善
- AboutページのE2Eテスト追加（3ケース）
- 並列実行による認証状態の干渉問題を修正
- workers を1に設定し、テストの安定性を向上

## テスト
- ✅ 全9件のE2Eテストがパス
- ✅ Aboutページの3つのシナリオを検証
  - ヘッダーからAboutページへのアクセス
  - 未ログイン時の新規登録ページへの遷移
  - ログイン時のトップページへの遷移

Closes #191