### PR TITLE
test: 認証・カード関連コンポーネントのユニットテスト追加とリファクタリング

### DIFF
--- a/frontend/src/app/(auth)/_components/AuthLayout.test.tsx
+++ b/frontend/src/app/(auth)/_components/AuthLayout.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import AuthLayout from './AuthLayout';
+
+describe('AuthLayout', () => {
+  describe('表示', () => {
+    it('タイトルが表示される', () => {
+      render(
+        <AuthLayout title="ログイン" alternativeText="新規登録" alternativeHref="/register">
+          <div>test content</div>
+        </AuthLayout>,
+      );
+
+      expect(screen.getByRole('heading', { name: 'ログイン' })).toBeInTheDocument();
+    });
+
+    it('children が表示される', () => {
+      render(
+        <AuthLayout title="ログイン" alternativeText="新規登録" alternativeHref="/register">
+          <div>test content</div>
+        </AuthLayout>,
+      );
+
+      expect(screen.getByText('test content')).toBeInTheDocument();
+    });
+
+    it('代替テキストとリンクが表示される', () => {
+      render(
+        <AuthLayout title="ログイン" alternativeText="新規登録" alternativeHref="/register">
+          <div>test content</div>
+        </AuthLayout>,
+      );
+
+      expect(screen.getByText('または')).toBeInTheDocument();
+
+      const link = screen.getByRole('link', { name: '新規登録' });
+      expect(link).toHaveAttribute('href', '/register');
+    });
+  });
+
+  describe('異なる props での動作', () => {
+    it('登録ページのレイアウトが正しく表示される', () => {
+      render(
+        <AuthLayout title="新規登録" alternativeText="ログイン" alternativeHref="/login">
+          <div>register form</div>
+        </AuthLayout>,
+      );
+
+      expect(screen.getByRole('heading', { name: '新規登録' })).toBeInTheDocument();
+
+      const link = screen.getByRole('link', { name: 'ログイン' });
+      expect(link).toHaveAttribute('href', '/login');
+
+      expect(screen.getByText('register form')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/app/(auth)/_components/PasswordResetForm.test.tsx
+++ b/frontend/src/app/(auth)/_components/PasswordResetForm.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePasswordResetForm } from '@/app/(auth)/_hooks/usePasswordResetForm';
+import PasswordResetForm from './PasswordResetForm';
+
+vi.mock('@/app/(auth)/_hooks/usePasswordResetForm', () => ({
+  usePasswordResetForm: vi.fn(),
+}));
+
+describe('PasswordResetForm', () => {
+  // ヘルパー関数: usePasswordResetForm のモックを設定
+  const mockUsePasswordResetForm = (overrides = {}) => {
+    vi.mocked(usePasswordResetForm).mockReturnValue({
+      router: {
+        push: vi.fn(),
+        replace: vi.fn(),
+        refresh: vi.fn(),
+        back: vi.fn(),
+        forward: vi.fn(),
+        prefetch: vi.fn(),
+      } as never,
+      isComplete: false,
+      register: vi.fn((name) => ({
+        onChange: vi.fn(),
+        onBlur: vi.fn(),
+        name,
+        ref: vi.fn(),
+      })),
+      handleSubmit: vi.fn(),
+      errors: {},
+      isSubmitting: false,
+      onSubmit: vi.fn(),
+      ...overrides,
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('フォーム表示', () => {
+    it('新しいパスワード入力欄が存在する', () => {
+      mockUsePasswordResetForm();
+
+      render(<PasswordResetForm />);
+
+      const input = screen.getByLabelText('新しいパスワード');
+      expect(input).toHaveAttribute('type', 'password');
+      expect(input).toHaveAttribute('placeholder', '新しいパスワードを入力');
+    });
+
+    it('パスワード確認入力欄が存在する', () => {
+      mockUsePasswordResetForm();
+
+      render(<PasswordResetForm />);
+
+      const input = screen.getByLabelText('パスワード（確認）');
+      expect(input).toHaveAttribute('type', 'password');
+      expect(input).toHaveAttribute('placeholder', 'パスワードを再入力');
+    });
+
+    it('パスワード変更ボタンが存在する', () => {
+      mockUsePasswordResetForm();
+
+      render(<PasswordResetForm />);
+
+      const button = screen.getByRole('button', { name: 'パスワードを変更' });
+      expect(button).toHaveAttribute('type', 'submit');
+      expect(button).not.toBeDisabled();
+    });
+
+    it('パスワードの要件が表示される', () => {
+      mockUsePasswordResetForm();
+
+      render(<PasswordResetForm />);
+
+      expect(
+        screen.getByText('パスワードは8文字以上で、英字と数字を含める必要があります。'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('エラー時', () => {
+    it('エラーメッセージが表示される', () => {
+      mockUsePasswordResetForm({
+        errors: {
+          password: { message: 'パスワードが間違っています' },
+          confirmPassword: { message: 'パスワードが一致しません' },
+        },
+      });
+
+      render(<PasswordResetForm />);
+
+      expect(screen.getByText('パスワードが間違っています')).toBeInTheDocument();
+      expect(screen.getByText('パスワードが一致しません')).toBeInTheDocument();
+    });
+
+    it('エラーがない場合はエラーメッセージが表示されない', () => {
+      mockUsePasswordResetForm();
+
+      render(<PasswordResetForm />);
+
+      expect(screen.queryByText('パスワードが間違っています')).not.toBeInTheDocument();
+      expect(screen.queryByText('パスワードが一致しません')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('送信中の状態', () => {
+    it('送信中はボタンのテキストが「変更中...」になる', () => {
+      mockUsePasswordResetForm({ isSubmitting: true });
+
+      render(<PasswordResetForm />);
+
+      expect(screen.getByText('変更中...')).toBeInTheDocument();
+    });
+
+    it('送信中はボタンが無効化される', () => {
+      mockUsePasswordResetForm({ isSubmitting: true });
+
+      render(<PasswordResetForm />);
+
+      const button = screen.getByRole('button', { name: '変更中...' });
+      expect(button).toBeDisabled();
+    });
+  });
+
+  describe('完了画面', () => {
+    it('パスワード変更完了時に完了メッセージが表示される', () => {
+      mockUsePasswordResetForm({ isComplete: true });
+
+      render(<PasswordResetForm />);
+
+      expect(screen.getByText('パスワードを変更しました')).toBeInTheDocument();
+      expect(
+        screen.getByText('新しいパスワードでログインできるようになりました。'),
+      ).toBeInTheDocument();
+    });
+
+    it('パスワード変更完了時に設定画面に戻るボタンが表示される', () => {
+      mockUsePasswordResetForm({ isComplete: true });
+
+      render(<PasswordResetForm />);
+
+      const button = screen.getByRole('button', { name: '設定画面に戻る' });
+      expect(button).toHaveAttribute('type', 'button');
+    });
+
+    it('完了画面ではフォームが表示されない', () => {
+      mockUsePasswordResetForm({ isComplete: true });
+
+      render(<PasswordResetForm />);
+
+      expect(screen.queryByLabelText('新しいパスワード')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('パスワード（確認）')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/app/(auth)/_components/forms/AuthInput.test.tsx
+++ b/frontend/src/app/(auth)/_components/forms/AuthInput.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AuthInput from './AuthInput';
+
+describe('AuthInput', () => {
+  const mockRegister = vi.fn((name) => ({
+    onChange: vi.fn(),
+    onBlur: vi.fn(),
+    name,
+    ref: vi.fn(),
+  }));
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('デフォルト設定', () => {
+    it('指定した属性値が設定されている', () => {
+      render(
+        <AuthInput
+          name="input-test"
+          label="test"
+          placeholder="placeholder"
+          register={mockRegister}
+        />,
+      );
+
+      const input = screen.getByLabelText('test');
+      expect(input).toHaveAttribute('id', 'input-test');
+      expect(input).toHaveAttribute('type', 'text');
+      expect(input).toHaveAttribute('placeholder', 'placeholder');
+      expect(input).toHaveAttribute('name', 'input-test');
+    });
+
+    it('register 関数が正しく呼び出される', () => {
+      render(
+        <AuthInput
+          name="input-test"
+          label="test"
+          placeholder="placeholder"
+          register={mockRegister}
+        />,
+      );
+
+      expect(mockRegister).toHaveBeenCalledWith('input-test');
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('type 属性のカスタマイズ', () => {
+    it('email 属性を設定できる', () => {
+      render(
+        <AuthInput
+          name="email-input"
+          label="Email"
+          type="email"
+          placeholder="placeholder"
+          register={mockRegister}
+        />,
+      );
+
+      const input = screen.getByLabelText('Email');
+      expect(input).toHaveAttribute('type', 'email');
+    });
+
+    it('password 属性を設定できる', () => {
+      render(
+        <AuthInput
+          name="password-input"
+          label="Password"
+          type="password"
+          placeholder="placeholder"
+          register={mockRegister}
+        />,
+      );
+
+      const input = screen.getByLabelText('Password');
+      expect(input).toHaveAttribute('type', 'password');
+    });
+  });
+
+  describe('エラー時', () => {
+    it('エラーメッセージが表示される', () => {
+      render(
+        <AuthInput
+          name="input-test"
+          label="test"
+          placeholder="placeholder"
+          register={mockRegister}
+          error="エラーです"
+        />,
+      );
+
+      expect(screen.getByText('エラーです')).toBeInTheDocument();
+    });
+
+    it('エラーがない場合はエラーメッセージが表示されない', () => {
+      render(
+        <AuthInput
+          name="input-test"
+          label="test"
+          placeholder="placeholder"
+          register={mockRegister}
+        />,
+      );
+
+      expect(screen.queryByText('エラーです')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/app/(auth)/_components/forms/LoginForm.test.tsx
+++ b/frontend/src/app/(auth)/_components/forms/LoginForm.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useLoginForm } from '@/app/(auth)/_hooks/useLoginForm';
+import LoginForm from './LoginForm';
+
+vi.mock('@/app/(auth)/_hooks/useLoginForm', () => ({
+  useLoginForm: vi.fn(),
+}));
+
+describe('LoginForm', () => {
+  // ヘルパー関数: useLoginForm のモックを設定
+  const mockUseLoginForm = (overrides = {}) => {
+    vi.mocked(useLoginForm).mockReturnValue({
+      register: vi.fn((name) => ({
+        onChange: vi.fn(),
+        onBlur: vi.fn(),
+        name,
+        ref: vi.fn(),
+      })),
+      handleSubmit: vi.fn(),
+      errors: {},
+      isSubmitting: false,
+      onSubmit: vi.fn(),
+      ...overrides,
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('表示', () => {
+    it('メールアドレス入力欄が存在する', () => {
+      mockUseLoginForm();
+
+      render(<LoginForm />);
+
+      const input = screen.getByLabelText('メールアドレス');
+      expect(input).toHaveAttribute('type', 'email');
+      expect(input).toHaveAttribute('placeholder', 'example@email.com');
+    });
+
+    it('パスワード入力欄が存在する', () => {
+      mockUseLoginForm();
+
+      render(<LoginForm />);
+
+      const input = screen.getByLabelText('パスワード');
+      expect(input).toHaveAttribute('type', 'password');
+      expect(input).toHaveAttribute('placeholder', 'パスワードを入力');
+    });
+
+    it('ログインボタンが存在する', () => {
+      mockUseLoginForm();
+
+      render(<LoginForm />);
+
+      const button = screen.getByRole('button', { name: 'ログイン' });
+      expect(button).toHaveAttribute('type', 'submit');
+      expect(button).not.toBeDisabled();
+    });
+  });
+
+  describe('エラー時', () => {
+    it('エラーメッセージが表示される', () => {
+      mockUseLoginForm({
+        errors: {
+          email: { message: 'メールアドレスが間違っています' },
+          password: { message: 'パスワードが間違っています' },
+        },
+      });
+
+      render(<LoginForm />);
+
+      expect(screen.getByText('メールアドレスが間違っています')).toBeInTheDocument();
+      expect(screen.getByText('パスワードが間違っています')).toBeInTheDocument();
+    });
+  });
+
+  describe('送信中の状態', () => {
+    it('送信中はボタンのテキストが「ログイン中...」になる', () => {
+      mockUseLoginForm({ isSubmitting: true });
+
+      render(<LoginForm />);
+
+      expect(screen.getByText('ログイン中...')).toBeInTheDocument();
+    });
+
+    it('送信中はボタンが無効化される', () => {
+      mockUseLoginForm({ isSubmitting: true });
+
+      render(<LoginForm />);
+
+      const button = screen.getByRole('button', { name: 'ログイン中...' });
+      expect(button).toBeDisabled();
+    });
+
+    it('送信中でない場合はボタンのテキストが「ログイン」になる', () => {
+      mockUseLoginForm({ isSubmitting: false });
+
+      render(<LoginForm />);
+
+      expect(screen.getByText('ログイン')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/app/(auth)/_components/forms/RegisterForm.test.tsx
+++ b/frontend/src/app/(auth)/_components/forms/RegisterForm.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useRegisterForm } from '@/app/(auth)/_hooks/useRegisterForm';
+import RegisterForm from './RegisterForm';
+
+vi.mock('@/app/(auth)/_hooks/useRegisterForm', () => ({
+  useRegisterForm: vi.fn(),
+}));
+
+describe('RegisterForm', () => {
+  // ヘルパー関数: useRegisterForm のモックを設定
+  const mockUseRegisterForm = (overrides = {}) => {
+    vi.mocked(useRegisterForm).mockReturnValue({
+      register: vi.fn((name) => ({
+        onChange: vi.fn(),
+        onBlur: vi.fn(),
+        name,
+        ref: vi.fn(),
+      })),
+      handleSubmit: vi.fn(),
+      errors: {},
+      isSubmitting: false,
+      onSubmit: vi.fn(),
+      ...overrides,
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('表示', () => {
+    it('ユーザー名入力欄が存在する', () => {
+      mockUseRegisterForm();
+
+      render(<RegisterForm />);
+
+      const input = screen.getByLabelText('ユーザー名');
+      expect(input).toHaveAttribute('type', 'text');
+      expect(input).toHaveAttribute('placeholder', 'ユーザー名を入力');
+    });
+
+    it('メールアドレス入力欄が存在する', () => {
+      mockUseRegisterForm();
+
+      render(<RegisterForm />);
+
+      const input = screen.getByLabelText('メールアドレス');
+      expect(input).toHaveAttribute('type', 'email');
+      expect(input).toHaveAttribute('placeholder', 'example@email.com');
+    });
+
+    it('パスワード入力欄が存在する', () => {
+      mockUseRegisterForm();
+
+      render(<RegisterForm />);
+
+      const input = screen.getByLabelText('パスワード');
+      expect(input).toHaveAttribute('type', 'password');
+      expect(input).toHaveAttribute('placeholder', '8文字以上で入力');
+    });
+
+    it('パスワード確認欄が存在する', () => {
+      mockUseRegisterForm();
+
+      render(<RegisterForm />);
+
+      const input = screen.getByLabelText('パスワード確認');
+      expect(input).toHaveAttribute('type', 'password');
+      expect(input).toHaveAttribute('placeholder', 'パスワードを再入力');
+    });
+
+    it('登録ボタンが存在する', () => {
+      mockUseRegisterForm();
+
+      render(<RegisterForm />);
+
+      const button = screen.getByRole('button', { name: '登録' });
+      expect(button).toHaveAttribute('type', 'submit');
+      expect(button).not.toBeDisabled();
+    });
+  });
+
+  describe('エラー時', () => {
+    it('エラーメッセージが表示される', () => {
+      mockUseRegisterForm({
+        errors: {
+          name: { message: 'ユーザー名が間違っています' },
+          email: { message: 'メールアドレスが間違っています' },
+          password: { message: 'パスワードが間違っています' },
+          passwordConfirmation: { message: 'パスワード確認が間違っています' },
+        },
+      });
+
+      render(<RegisterForm />);
+
+      expect(screen.getByText('ユーザー名が間違っています')).toBeInTheDocument();
+      expect(screen.getByText('メールアドレスが間違っています')).toBeInTheDocument();
+      expect(screen.getByText('パスワードが間違っています')).toBeInTheDocument();
+      expect(screen.getByText('パスワード確認が間違っています')).toBeInTheDocument();
+    });
+  });
+
+  describe('送信中の状態', () => {
+    it('送信中はボタンのテキストが「登録中...」になる', () => {
+      mockUseRegisterForm({ isSubmitting: true });
+
+      render(<RegisterForm />);
+
+      expect(screen.getByText('登録中...')).toBeInTheDocument();
+    });
+
+    it('送信中はボタンが無効化される', () => {
+      mockUseRegisterForm({ isSubmitting: true });
+
+      render(<RegisterForm />);
+
+      const button = screen.getByRole('button', { name: '登録中...' });
+      expect(button).toBeDisabled();
+    });
+
+    it('送信中でない場合はボタンのテキストが「登録」になる', () => {
+      mockUseRegisterForm({ isSubmitting: false });
+
+      render(<RegisterForm />);
+
+      expect(screen.getByText('登録')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/app/(auth)/_hooks/useLoginForm.test.ts
+++ b/frontend/src/app/(auth)/_hooks/useLoginForm.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { loginAction, loginClientSide } from '../_lib';
+import { act, renderHook } from '@testing-library/react';
+import { useLoginForm } from './useLoginForm';
+import { LoginFormData } from '@/schemas/auth';
+import toast from 'react-hot-toast';
+
+// Next.js の useRouter をモック
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(() => ({
+    push: mockPush,
+  })),
+}));
+
+// 認証関連の関数をモック
+vi.mock('@/app/(auth)/_lib', () => ({
+  loginAction: vi.fn(),
+  loginClientSide: vi.fn(),
+}));
+
+// react-hot-toast をモック
+vi.mock('react-hot-toast', () => ({
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('useLoginForm', () => {
+  const mockLoginFormData: LoginFormData = {
+    email: 'test@example.com',
+    password: 'testpassword1234',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('初期状態', () => {
+    it('onSubmit 関数が返される', () => {
+      const { result } = renderHook(() => useLoginForm());
+
+      expect(result.current.onSubmit).toBeDefined();
+      expect(typeof result.current.onSubmit).toBe('function');
+    });
+  });
+
+  describe('onSubmit: 正常系', () => {
+    beforeEach(() => {
+      vi.mocked(loginClientSide).mockResolvedValue(null);
+      vi.mocked(loginAction).mockResolvedValue({ success: true });
+    });
+
+    it('loginClientside が呼ばれる', async () => {
+      const { result } = renderHook(() => useLoginForm());
+
+      await act(() => result.current.onSubmit(mockLoginFormData));
+
+      expect(loginClientSide).toHaveBeenCalledWith(mockLoginFormData);
+    });
+
+    it('loginAction が呼ばれる', async () => {
+      const { result } = renderHook(() => useLoginForm());
+
+      await act(() => result.current.onSubmit(mockLoginFormData));
+
+      expect(loginAction).toHaveBeenCalledWith(mockLoginFormData);
+    });
+
+    it('トーストが表示され、ログイン後トップページへ遷移する', async () => {
+      const { result } = renderHook(() => useLoginForm());
+
+      await act(() => result.current.onSubmit(mockLoginFormData));
+
+      expect(toast.success).toHaveBeenCalledWith('ログインしました');
+      expect(mockPush).toHaveBeenCalledWith('/top');
+    });
+  });
+
+  describe('onSubmit: 異常系', () => {
+    it('loginClientSide のエラーメッセージがトーストで表示される', async () => {
+      vi.mocked(loginClientSide).mockResolvedValue('エラーです');
+
+      const { result } = renderHook(() => useLoginForm());
+
+      await act(() => result.current.onSubmit(mockLoginFormData));
+
+      expect(toast.error).toHaveBeenCalledWith('エラーです');
+    });
+
+    it('loginAction のエラーメッセージがトーストで表示される', async () => {
+      vi.mocked(loginClientSide).mockResolvedValue(null);
+      vi.mocked(loginAction).mockResolvedValue({ error: 'エラーです' });
+
+      const { result } = renderHook(() => useLoginForm());
+
+      await act(() => result.current.onSubmit(mockLoginFormData));
+
+      expect(toast.error).toHaveBeenCalledWith('エラーです');
+    });
+
+    it('トップページに遷移されない', async () => {
+      vi.mocked(loginClientSide).mockResolvedValue(null);
+      vi.mocked(loginAction).mockResolvedValue({ error: 'エラーです' });
+
+      const { result } = renderHook(() => useLoginForm());
+
+      await act(() => result.current.onSubmit(mockLoginFormData));
+
+      expect(toast.success).not.toHaveBeenCalledWith('ログインしました');
+      expect(mockPush).not.toHaveBeenCalledWith('/top');
+    });
+  });
+});

--- a/frontend/src/app/(auth)/_hooks/useLoginForm.test.ts
+++ b/frontend/src/app/(auth)/_hooks/useLoginForm.test.ts
@@ -49,7 +49,7 @@ describe('useLoginForm', () => {
   describe('onSubmit: 正常系', () => {
     beforeEach(() => {
       vi.mocked(loginClientSide).mockResolvedValue(null);
-      vi.mocked(loginAction).mockResolvedValue({ success: true });
+      vi.mocked(loginAction).mockResolvedValue(null);
     });
 
     it('loginClientside が呼ばれる', async () => {
@@ -91,7 +91,7 @@ describe('useLoginForm', () => {
 
     it('loginAction のエラーメッセージがトーストで表示される', async () => {
       vi.mocked(loginClientSide).mockResolvedValue(null);
-      vi.mocked(loginAction).mockResolvedValue({ error: 'エラーです' });
+      vi.mocked(loginAction).mockResolvedValue('エラーです');
 
       const { result } = renderHook(() => useLoginForm());
 
@@ -102,7 +102,7 @@ describe('useLoginForm', () => {
 
     it('トップページに遷移されない', async () => {
       vi.mocked(loginClientSide).mockResolvedValue(null);
-      vi.mocked(loginAction).mockResolvedValue({ error: 'エラーです' });
+      vi.mocked(loginAction).mockResolvedValue('エラーです');
 
       const { result } = renderHook(() => useLoginForm());
 

--- a/frontend/src/app/(auth)/_hooks/useLoginForm.ts
+++ b/frontend/src/app/(auth)/_hooks/useLoginForm.ts
@@ -26,17 +26,15 @@ export function useLoginForm() {
     }
 
     // 2. サーバー側のセッションも設定
-    const result = await loginAction(data);
+    const serverError = await loginAction(data);
 
-    if (result?.error) {
-      toast.error(result.error);
+    if (serverError) {
+      toast.error(serverError);
       return;
     }
 
-    if (result?.success) {
-      toast.success('ログインしました');
-      router.push('/top');
-    }
+    toast.success('ログインしました');
+    router.push('/top');
   };
 
   return {

--- a/frontend/src/app/(auth)/_hooks/useLogout.test.ts
+++ b/frontend/src/app/(auth)/_hooks/useLogout.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLogout } from './useLogout';
+import { logoutAction, logoutClientSide } from '@/app/(auth)/_lib';
+import toast from 'react-hot-toast';
+
+// Next.jsのuseRouterをモック
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(() => ({
+    push: mockPush,
+  })),
+}));
+
+// React QueryのuseQueryClientをモック
+const mockClear = vi.fn();
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: vi.fn(() => ({
+    clear: mockClear,
+  })),
+}));
+
+// 認証関連の関数をモック
+vi.mock('@/app/(auth)/_lib', () => ({
+  logoutAction: vi.fn(),
+  logoutClientSide: vi.fn(),
+}));
+
+// react-hot-toastをモック
+vi.mock('react-hot-toast', () => ({
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('useLogout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('初期状態', () => {
+    it('loading が false で初期化される', () => {
+      const { result } = renderHook(() => useLogout());
+
+      expect(result.current.loading).toBe(false);
+    });
+
+    it('logout 関数が返される', () => {
+      const { result } = renderHook(() => useLogout());
+
+      expect(result.current.logout).toBeDefined();
+      expect(typeof result.current.logout).toBe('function');
+    });
+  });
+
+  describe('logout: 正常系', () => {
+    beforeEach(() => {
+      vi.mocked(logoutClientSide).mockResolvedValue(null);
+      vi.mocked(logoutAction).mockResolvedValue({ success: true });
+    });
+
+    it('logoutClientSide が呼ばれる', async () => {
+      const { result } = renderHook(() => useLogout());
+
+      await act(() => result.current.logout());
+
+      expect(logoutClientSide).toHaveBeenCalled();
+    });
+
+    it('logoutAction が呼ばれる', async () => {
+      const { result } = renderHook(() => useLogout());
+
+      await act(() => result.current.logout());
+
+      expect(logoutAction).toHaveBeenCalled();
+    });
+
+    it('queryClient.clear (キャッシュクリア) が呼ばれる', async () => {
+      const { result } = renderHook(() => useLogout());
+
+      await act(() => result.current.logout());
+
+      expect(mockClear).toHaveBeenCalled();
+    });
+
+    it('トーストが表示され、トップページへ遷移する', async () => {
+      const { result } = renderHook(() => useLogout());
+
+      await act(() => result.current.logout());
+
+      expect(toast.success).toHaveBeenCalledWith('ログアウトしました');
+      expect(mockPush).toHaveBeenCalledWith('/');
+    });
+  });
+
+  describe('logout: 異常系', () => {
+    it('logoutClientSide のエラーメッセージがトーストで表示される', async () => {
+      vi.mocked(logoutClientSide).mockResolvedValue('エラーです');
+
+      const { result } = renderHook(() => useLogout());
+
+      await act(() => result.current.logout());
+
+      expect(toast.error).toHaveBeenCalledWith('エラーです');
+      expect(result.current.loading).toBe(false);
+    });
+
+    it('logoutAction のエラーメッセージがトーストで表示される', async () => {
+      vi.mocked(logoutClientSide).mockResolvedValue(null);
+      vi.mocked(logoutAction).mockResolvedValue({ error: 'エラーです' });
+
+      const { result } = renderHook(() => useLogout());
+
+      await act(() => result.current.logout());
+
+      expect(toast.error).toHaveBeenCalledWith('エラーです');
+      expect(result.current.loading).toBe(false);
+    });
+
+    it('queryClient.clear (キャッシュクリア)が呼ばれない', async () => {
+      vi.mocked(logoutClientSide).mockResolvedValue(null);
+      vi.mocked(logoutAction).mockResolvedValue({ error: 'エラーです' });
+
+      const { result } = renderHook(() => useLogout());
+
+      await act(() => result.current.logout());
+
+      expect(mockClear).not.toHaveBeenCalled();
+    });
+
+    it('トップページに遷移されない', async () => {
+      vi.mocked(logoutClientSide).mockResolvedValue(null);
+      vi.mocked(logoutAction).mockResolvedValue({ error: 'エラーです' });
+
+      const { result } = renderHook(() => useLogout());
+
+      await act(() => result.current.logout());
+
+      expect(toast.success).not.toHaveBeenCalledWith('ログアウトしました');
+      expect(mockPush).not.toHaveBeenCalledWith('/');
+    });
+  });
+});

--- a/frontend/src/app/(auth)/_hooks/useLogout.test.ts
+++ b/frontend/src/app/(auth)/_hooks/useLogout.test.ts
@@ -57,7 +57,7 @@ describe('useLogout', () => {
   describe('logout: 正常系', () => {
     beforeEach(() => {
       vi.mocked(logoutClientSide).mockResolvedValue(null);
-      vi.mocked(logoutAction).mockResolvedValue({ success: true });
+      vi.mocked(logoutAction).mockResolvedValue(null);
     });
 
     it('logoutClientSide が呼ばれる', async () => {
@@ -108,7 +108,7 @@ describe('useLogout', () => {
 
     it('logoutAction のエラーメッセージがトーストで表示される', async () => {
       vi.mocked(logoutClientSide).mockResolvedValue(null);
-      vi.mocked(logoutAction).mockResolvedValue({ error: 'エラーです' });
+      vi.mocked(logoutAction).mockResolvedValue('エラーです');
 
       const { result } = renderHook(() => useLogout());
 
@@ -120,7 +120,7 @@ describe('useLogout', () => {
 
     it('queryClient.clear (キャッシュクリア)が呼ばれない', async () => {
       vi.mocked(logoutClientSide).mockResolvedValue(null);
-      vi.mocked(logoutAction).mockResolvedValue({ error: 'エラーです' });
+      vi.mocked(logoutAction).mockResolvedValue('エラーです');
 
       const { result } = renderHook(() => useLogout());
 
@@ -131,7 +131,7 @@ describe('useLogout', () => {
 
     it('トップページに遷移されない', async () => {
       vi.mocked(logoutClientSide).mockResolvedValue(null);
-      vi.mocked(logoutAction).mockResolvedValue({ error: 'エラーです' });
+      vi.mocked(logoutAction).mockResolvedValue('エラーです');
 
       const { result } = renderHook(() => useLogout());
 

--- a/frontend/src/app/(auth)/_hooks/useLogout.ts
+++ b/frontend/src/app/(auth)/_hooks/useLogout.ts
@@ -12,33 +12,28 @@ export function useLogout() {
   const logout = async () => {
     setLoading(true);
 
-    try {
-      // 1. クライアント側でログアウト（重要: タブ間同期のため）
-      const clientError = await logoutClientSide();
+    // 1. クライアント側でログアウト（重要: タブ間同期のため）
+    const clientError = await logoutClientSide();
 
-      if (clientError) {
-        toast.error(clientError);
-        setLoading(false);
-        return;
-      }
-
-      // 2. サーバー側のセッションもクリア
-      const result = await logoutAction();
-
-      if (result?.error) {
-        toast.error(result.error);
-        setLoading(false);
-        return;
-      }
-
-      // 3. React Queryのキャッシュをクリア
-      queryClient.clear();
-      toast.success('ログアウトしました');
-      router.push('/');
-    } catch (_error) {
-      toast.error('エラーが発生しました。もう一度お試しください');
+    if (clientError) {
+      toast.error(clientError);
       setLoading(false);
+      return;
     }
+
+    // 2. サーバー側のセッションもクリア
+    const result = await logoutAction();
+
+    if (result?.error) {
+      toast.error(result.error);
+      setLoading(false);
+      return;
+    }
+
+    // 3. React Queryのキャッシュをクリア
+    queryClient.clear();
+    toast.success('ログアウトしました');
+    router.push('/');
   };
 
   return {

--- a/frontend/src/app/(auth)/_hooks/useLogout.ts
+++ b/frontend/src/app/(auth)/_hooks/useLogout.ts
@@ -22,10 +22,10 @@ export function useLogout() {
     }
 
     // 2. サーバー側のセッションもクリア
-    const result = await logoutAction();
+    const serverError = await logoutAction();
 
-    if (result?.error) {
-      toast.error(result.error);
+    if (serverError) {
+      toast.error(serverError);
       setLoading(false);
       return;
     }

--- a/frontend/src/app/(auth)/_hooks/useRegisterForm.test.ts
+++ b/frontend/src/app/(auth)/_hooks/useRegisterForm.test.ts
@@ -49,7 +49,7 @@ describe('useRegisterForm', () => {
 
   describe('onSubmit: 正常系', () => {
     beforeEach(() => {
-      vi.mocked(signUpAction).mockResolvedValue({ success: true });
+      vi.mocked(signUpAction).mockResolvedValue(null);
     });
 
     it('signUpAction が呼ばれる', async () => {
@@ -76,7 +76,7 @@ describe('useRegisterForm', () => {
 
   describe('onSubmit: 異常系', () => {
     beforeEach(() => {
-      vi.mocked(signUpAction).mockResolvedValue({ error: 'エラーです' });
+      vi.mocked(signUpAction).mockResolvedValue('エラーです');
     });
 
     it('signUpAction のエラーメッセージがトーストで表示される', async () => {

--- a/frontend/src/app/(auth)/_hooks/useRegisterForm.test.ts
+++ b/frontend/src/app/(auth)/_hooks/useRegisterForm.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { signUpAction } from '../_lib';
+import { RegisterFormData } from '@/schemas/auth';
+import { useRegisterForm } from './useRegisterForm';
+import toast from 'react-hot-toast';
+
+// Next.js の useRouter をモック
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(() => ({
+    push: mockPush,
+  })),
+}));
+
+// 認証関連の関数をモック
+vi.mock('@/app/(auth)/_lib', () => ({
+  signUpAction: vi.fn(),
+}));
+
+// react-hot-toast をモック
+vi.mock('react-hot-toast', () => ({
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('useRegisterForm', () => {
+  const mockRegisterFormData: RegisterFormData = {
+    name: 'test-user',
+    email: 'test@example.com',
+    password: 'testpassword1234',
+    passwordConfirmation: 'testpassword1234',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('初期状態', () => {
+    it('onSubmit 関数が返される', () => {
+      const { result } = renderHook(() => useRegisterForm());
+
+      expect(result.current.onSubmit).toBeDefined();
+      expect(typeof result.current.onSubmit).toBe('function');
+    });
+  });
+
+  describe('onSubmit: 正常系', () => {
+    beforeEach(() => {
+      vi.mocked(signUpAction).mockResolvedValue({ success: true });
+    });
+
+    it('signUpAction が呼ばれる', async () => {
+      const { result } = renderHook(() => useRegisterForm());
+
+      await act(() => result.current.onSubmit(mockRegisterFormData));
+
+      expect(signUpAction).toHaveBeenCalledWith(
+        mockRegisterFormData.name,
+        mockRegisterFormData.email,
+        mockRegisterFormData.password,
+      );
+    });
+
+    it('トーストが表示され、トップページへ遷移する', async () => {
+      const { result } = renderHook(() => useRegisterForm());
+
+      await act(() => result.current.onSubmit(mockRegisterFormData));
+
+      expect(toast.success).toHaveBeenCalledWith('ユーザー登録が完了しました');
+      expect(mockPush).toHaveBeenCalledWith('/top');
+    });
+  });
+
+  describe('onSubmit: 異常系', () => {
+    beforeEach(() => {
+      vi.mocked(signUpAction).mockResolvedValue({ error: 'エラーです' });
+    });
+
+    it('signUpAction のエラーメッセージがトーストで表示される', async () => {
+      const { result } = renderHook(() => useRegisterForm());
+
+      await act(() => result.current.onSubmit(mockRegisterFormData));
+
+      expect(toast.error).toHaveBeenCalledWith('エラーです');
+    });
+
+    it('トップページへ遷移されない', async () => {
+      const { result } = renderHook(() => useRegisterForm());
+
+      await act(() => result.current.onSubmit(mockRegisterFormData));
+
+      expect(toast.success).not.toHaveBeenCalledWith('ユーザー登録が完了しました');
+      expect(mockPush).not.toHaveBeenCalledWith('/top');
+    });
+  });
+});

--- a/frontend/src/app/(auth)/_hooks/useRegisterForm.ts
+++ b/frontend/src/app/(auth)/_hooks/useRegisterForm.ts
@@ -21,6 +21,7 @@ export function useRegisterForm() {
 
     if (result?.error) {
       toast.error(result.error);
+      return;
     }
 
     if (result?.success) {

--- a/frontend/src/app/(auth)/_hooks/useRegisterForm.ts
+++ b/frontend/src/app/(auth)/_hooks/useRegisterForm.ts
@@ -17,17 +17,15 @@ export function useRegisterForm() {
   });
 
   const onSubmit = async (data: RegisterFormData) => {
-    const result = await signUpAction(data.name, data.email, data.password);
+    const error = await signUpAction(data.name, data.email, data.password);
 
-    if (result?.error) {
-      toast.error(result.error);
+    if (error) {
+      toast.error(error);
       return;
     }
 
-    if (result?.success) {
-      toast.success('ユーザー登録が完了しました');
-      router.push('/top');
-    }
+    toast.success('ユーザー登録が完了しました');
+    router.push('/top');
   };
 
   return {

--- a/frontend/src/app/(auth)/_lib/session.test.ts
+++ b/frontend/src/app/(auth)/_lib/session.test.ts
@@ -32,7 +32,7 @@ describe('loginAction', () => {
 
       const result = await loginAction({ email: 'test@example.com', password: 'password123' });
 
-      expect(result).toEqual({ success: true });
+      expect(result).toEqual(null);
       expect(mockSupabase.auth.signInWithPassword).toHaveBeenCalledWith({
         email: 'test@example.com',
         password: 'password123',
@@ -58,7 +58,7 @@ describe('loginAction', () => {
 
       const result = await loginAction({ email: 'test@example.com', password: 'wrong' });
 
-      expect(result).toEqual({ error: translatedError });
+      expect(result).toEqual(translatedError);
       expect(translateAuthError).toHaveBeenCalledWith(mockError);
       expect(revalidatePath).not.toHaveBeenCalled();
     });
@@ -81,7 +81,7 @@ describe('logoutAction', () => {
 
       const result = await logoutAction();
 
-      expect(result).toEqual({ success: true });
+      expect(result).toEqual(null);
       expect(mockSupabase.auth.signOut).toHaveBeenCalled();
       expect(revalidatePath).toHaveBeenCalledWith('/', 'layout');
     });
@@ -104,7 +104,7 @@ describe('logoutAction', () => {
 
       const result = await logoutAction();
 
-      expect(result).toEqual({ error: translatedError });
+      expect(result).toEqual(translatedError);
       expect(translateAuthError).toHaveBeenCalledWith(mockError);
       expect(revalidatePath).not.toHaveBeenCalled();
     });
@@ -127,7 +127,7 @@ describe('signUpAction', () => {
 
       const result = await signUpAction('Test User', 'test@example.com', 'password123');
 
-      expect(result).toEqual({ success: true });
+      expect(result).toEqual(null);
       expect(mockSupabase.auth.signUp).toHaveBeenCalledWith({
         email: 'test@example.com',
         password: 'password123',
@@ -179,7 +179,7 @@ describe('signUpAction', () => {
 
       const result = await signUpAction('Test User', 'existing@example.com', 'password123');
 
-      expect(result).toEqual({ error: translatedError });
+      expect(result).toEqual(translatedError);
       expect(translateAuthError).toHaveBeenCalledWith(mockError);
       expect(revalidatePath).not.toHaveBeenCalled();
     });

--- a/frontend/src/app/(auth)/_lib/session.ts
+++ b/frontend/src/app/(auth)/_lib/session.ts
@@ -5,33 +5,37 @@ import { LoginFormData } from '@/schemas/auth';
 import { createServerSupabaseClient } from '@/supabase/clients/server';
 import { translateAuthError } from '@/lib/utils/translateAuthError';
 
-export async function loginAction(formData: LoginFormData) {
+export async function loginAction(formData: LoginFormData): Promise<string | null> {
   const supabase = await createServerSupabaseClient();
 
   const { error } = await supabase.auth.signInWithPassword(formData);
 
   if (error) {
-    return { error: translateAuthError(error.message) };
+    return translateAuthError(error.message);
   }
 
   revalidatePath('/', 'layout');
-  return { success: true };
+  return null;
 }
 
-export async function logoutAction() {
+export async function logoutAction(): Promise<string | null> {
   const supabase = await createServerSupabaseClient();
 
   const { error } = await supabase.auth.signOut();
 
   if (error) {
-    return { error: translateAuthError(error.message) };
+    return translateAuthError(error.message);
   }
 
   revalidatePath('/', 'layout');
-  return { success: true };
+  return null;
 }
 
-export async function signUpAction(name: string, email: string, password: string) {
+export async function signUpAction(
+  name: string,
+  email: string,
+  password: string,
+): Promise<string | null> {
   const supabase = await createServerSupabaseClient();
 
   const { error } = await supabase.auth.signUp({
@@ -45,9 +49,9 @@ export async function signUpAction(name: string, email: string, password: string
   });
 
   if (error) {
-    return { error: translateAuthError(error.message) };
+    return translateAuthError(error.message);
   }
 
   revalidatePath('/', 'layout');
-  return { success: true };
+  return null;
 }

--- a/frontend/src/app/(protected)/books/_components/forms/index.tsx
+++ b/frontend/src/app/(protected)/books/_components/forms/index.tsx
@@ -83,13 +83,9 @@ export default function BookForm({ book, submitLabel, cancel }: BookFormProps) {
             setValueAs: (v) => (v === '' ? undefined : Number(v)),
           }}
           button={
-            <button
-              type="button"
-              onClick={categoryModal.open}
-              className="text-sm text-blue-600 hover:text-blue-700"
-            >
+            <Button type="button" variant="ghost" onClick={categoryModal.open}>
               + カテゴリを追加
-            </button>
+            </Button>
           }
         />
         {/* タグ */}
@@ -98,13 +94,9 @@ export default function BookForm({ book, submitLabel, cancel }: BookFormProps) {
             <label htmlFor="tags" className="font-semibold text-gray-700">
               タグ
             </label>
-            <button
-              type="button"
-              onClick={tagModal.open}
-              className="text-sm text-blue-600 hover:text-blue-700"
-            >
+            <Button type="button" variant="ghost" onClick={tagModal.open}>
               + タグを追加
-            </button>
+            </Button>
           </div>
           <Controller
             name="tag_ids"
@@ -141,7 +133,7 @@ export default function BookForm({ book, submitLabel, cancel }: BookFormProps) {
         />
 
         <div className="flex justify-end gap-3">
-          <Button variant="cancel" onClick={cancel}>
+          <Button variant="secondary" onClick={cancel}>
             キャンセル
           </Button>
           <Button

--- a/frontend/src/app/(protected)/cards/_components/display/BookCardGroup.tsx
+++ b/frontend/src/app/(protected)/cards/_components/display/BookCardGroup.tsx
@@ -25,7 +25,11 @@ export default function BookCardGroup({ book, cards }: BookCardGroupProps) {
         <h2 className="text-xl font-bold text-gray-900 w-full sm:flex-1 min-w-0 truncate">
           {book.title}
         </h2>
-        <Button variant="create" onClick={cardModal.open} icon={<StickyNote className="h-4 w-4" />}>
+        <Button
+          variant="primary"
+          onClick={cardModal.open}
+          icon={<StickyNote className="h-4 w-4" />}
+        >
           カードを作成
         </Button>
       </div>

--- a/frontend/src/app/(protected)/cards/_components/display/CardItem.tsx
+++ b/frontend/src/app/(protected)/cards/_components/display/CardItem.tsx
@@ -1,37 +1,18 @@
 'use client';
 
+import { Flag } from 'lucide-react';
 import { Card } from '@/app/(protected)/cards/_types';
 import Button from '@/components/buttons/Button';
-import { DetailLink } from '@/components/links';
-import { useCardMutations } from '@/app/(protected)/cards/_hooks/useCardMutations';
 import StatusBadge from '@/components/badges/StatusBadge';
-import { useRouter } from 'next/navigation';
-import { Flag } from 'lucide-react';
+import { DetailLink } from '@/components/links';
+import { useCardItem } from '@/app/(protected)/cards/_hooks/useCardItem';
 
 interface CardItemProps {
   card: Card;
 }
 
 export default function CardItem({ card }: CardItemProps) {
-  const router = useRouter();
-  const { deleteCard } = useCardMutations();
-
-  const handleDelete = () => {
-    if (!confirm('本当に削除しますか？')) {
-      return;
-    }
-
-    if (card) {
-      deleteCard(
-        { bookId: card.book_id, cardId: card.id },
-        {
-          onSuccess: () => {
-            router.push('/cards');
-          },
-        },
-      );
-    }
-  };
+  const { handleDelete } = useCardItem(card);
 
   return (
     <div className="border-b border-gray-200 p-4 last:border-b-0">

--- a/frontend/src/app/(protected)/cards/_components/display/CardItem.tsx
+++ b/frontend/src/app/(protected)/cards/_components/display/CardItem.tsx
@@ -55,7 +55,7 @@ export default function CardItem({ card }: CardItemProps) {
         {/* アクションボタン */}
         <div className="flex-shrink-0 flex gap-2 justify-center sm:justify-start">
           <DetailLink href={`/cards/${card.id}`} />
-          <Button variant="delete" onClick={handleDelete}>
+          <Button variant="danger" onClick={handleDelete}>
             削除
           </Button>
         </div>

--- a/frontend/src/app/(protected)/cards/_components/form/index.tsx
+++ b/frontend/src/app/(protected)/cards/_components/form/index.tsx
@@ -66,18 +66,14 @@ export default function CardForm({ card, bookId, onClose, submitLabel }: CardFor
             setValueAs: (v) => (v === '' ? undefined : Number(v)),
           }}
           button={
-            <button
-              type="button"
-              onClick={statusModal.open}
-              className="text-sm text-blue-600 hover:text-blue-700 hover: cursor-pointer"
-            >
+            <Button type="button" variant="ghost" onClick={statusModal.open}>
               + ステータスを追加
-            </button>
+            </Button>
           }
         />
 
         <div className="flex justify-end gap-3">
-          <Button variant="cancel" onClick={onClose}>
+          <Button variant="secondary" onClick={onClose}>
             キャンセル
           </Button>
           <Button

--- a/frontend/src/app/(protected)/cards/_hooks/useCardForm.test.ts
+++ b/frontend/src/app/(protected)/cards/_hooks/useCardForm.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { createMockCard } from '@/test/factories';
+import { useCardForm } from './useCardForm';
+import { createTestUuid } from '@/test/helpers';
+
+const mockCreateCard = vi.fn();
+const mockUpdateCard = vi.fn();
+vi.mock('@/app/(protected)/cards/_hooks/useCardMutations', () => ({
+  useCardMutations: vi.fn(() => ({
+    createCard: mockCreateCard,
+    updateCard: mockUpdateCard,
+    isCreating: false,
+    isUpdating: false,
+  })),
+}));
+
+const mockCancel = vi.fn();
+const mockCard = createMockCard();
+
+const mockCardFormData = {
+  book_id: mockCard.book_id,
+  title: mockCard.title,
+  content: mockCard.content,
+  status_id: mockCard.status?.id,
+};
+
+describe('useCardForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('更新時', () => {
+    it('updateCard が呼ばれる', () => {
+      const { result } = renderHook(() =>
+        useCardForm({ card: mockCard, bookId: mockCard.book_id, cancel: mockCancel }),
+      );
+
+      result.current.onSubmit(mockCardFormData);
+
+      expect(mockUpdateCard).toHaveBeenCalledWith(
+        {
+          ...mockCardFormData,
+          id: mockCard.id,
+        },
+        expect.objectContaining({
+          onSuccess: expect.any(Function),
+        }),
+      );
+    });
+
+    it('cancel(モーダルを閉じる)が実行される', () => {
+      const { result } = renderHook(() =>
+        useCardForm({ card: mockCard, bookId: mockCard.book_id, cancel: mockCancel }),
+      );
+
+      result.current.onSubmit(mockCardFormData);
+      expect(mockUpdateCard).toHaveBeenCalled();
+
+      const onSuccessCallback = mockUpdateCard.mock.calls[0][1].onSuccess;
+      onSuccessCallback();
+
+      expect(mockCancel).toHaveBeenCalled();
+    });
+  });
+
+  describe('作成時', () => {
+    it('createCard が呼ばれる', () => {
+      const { result } = renderHook(() =>
+        useCardForm({ bookId: createTestUuid(1), cancel: mockCancel }),
+      );
+
+      result.current.onSubmit(mockCardFormData);
+      expect(mockCreateCard).toHaveBeenCalledWith(
+        mockCardFormData,
+        expect.objectContaining({
+          onSuccess: expect.any(Function),
+        }),
+      );
+    });
+
+    it('cancel(モーダルを閉じる)が実行される', () => {
+      const { result } = renderHook(() =>
+        useCardForm({ bookId: createTestUuid(1), cancel: mockCancel }),
+      );
+
+      result.current.onSubmit(mockCardFormData);
+      expect(mockCreateCard).toHaveBeenCalled();
+
+      const onSuccessCallback = mockCreateCard.mock.calls[0][1].onSuccess;
+      onSuccessCallback();
+
+      expect(mockCancel).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/app/(protected)/cards/_hooks/useCardItem.test.ts
+++ b/frontend/src/app/(protected)/cards/_hooks/useCardItem.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { createMockCard } from '@/test/factories';
+import { useCardItem } from './useCardItem';
+
+// Next.jsのuseRouterをモック
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(() => ({
+    push: mockPush,
+  })),
+}));
+
+const mockDeleteCard = vi.fn();
+vi.mock('@/app/(protected)/cards/_hooks/useCardMutations', () => ({
+  useCardMutations: vi.fn(() => ({
+    deleteCard: mockDeleteCard,
+  })),
+}));
+
+const mockCard = createMockCard();
+
+describe('useCardItem', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('削除確認でキャンセルした場合、deleteCard が呼ばれない', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+    const { result } = renderHook(() => useCardItem(mockCard));
+
+    result.current.handleDelete();
+
+    expect(confirmSpy).toHaveBeenCalledWith('本当に削除しますか？');
+    expect(mockDeleteCard).not.toHaveBeenCalled();
+  });
+
+  it('削除確認で OK した場合、deleteCard が呼ばれる', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    const { result } = renderHook(() => useCardItem(mockCard));
+
+    result.current.handleDelete();
+
+    expect(confirmSpy).toHaveBeenCalledWith('本当に削除しますか？');
+    expect(mockDeleteCard).toHaveBeenCalledWith(
+      { bookId: mockCard.book_id, cardId: mockCard.id },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+      }),
+    );
+  });
+
+  it('削除完了後、カード一覧ページへ遷移する', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    const { result } = renderHook(() => useCardItem(mockCard));
+
+    result.current.handleDelete();
+
+    expect(confirmSpy).toHaveBeenCalledWith('本当に削除しますか？');
+    expect(mockDeleteCard).toHaveBeenCalled();
+
+    // onSuccess コールバックを取得して実行
+    const onSuccessCallback = mockDeleteCard.mock.calls[0][1].onSuccess;
+    onSuccessCallback();
+
+    // その後に router.push が呼ばれることを確認
+    expect(mockPush).toHaveBeenCalledWith('/cards');
+  });
+});

--- a/frontend/src/app/(protected)/cards/_hooks/useCardItem.ts
+++ b/frontend/src/app/(protected)/cards/_hooks/useCardItem.ts
@@ -1,0 +1,25 @@
+import { useRouter } from 'next/navigation';
+import { Card } from '@/app/(protected)/cards/_types';
+import { useCardMutations } from '@/app/(protected)/cards/_hooks/useCardMutations';
+
+export function useCardItem(card: Card) {
+  const router = useRouter();
+  const { deleteCard } = useCardMutations();
+
+  const handleDelete = () => {
+    if (!confirm('本当に削除しますか？')) {
+      return;
+    }
+
+    deleteCard(
+      { bookId: card.book_id, cardId: card.id },
+      {
+        onSuccess: () => {
+          router.push('/cards');
+        },
+      },
+    );
+  };
+
+  return { handleDelete };
+}

--- a/frontend/src/app/(protected)/categories/_components/forms/index.tsx
+++ b/frontend/src/app/(protected)/categories/_components/forms/index.tsx
@@ -33,7 +33,7 @@ export default function CategoryForm({ category, submitLabel, cancel }: Category
       </div>
 
       <div className="flex justify-end gap-3">
-        <Button variant="cancel" onClick={cancel}>
+        <Button variant="secondary" onClick={cancel}>
           キャンセル
         </Button>
         <Button

--- a/frontend/src/app/(protected)/lists/_components/display/view/ListIndexView.tsx
+++ b/frontend/src/app/(protected)/lists/_components/display/view/ListIndexView.tsx
@@ -20,7 +20,7 @@ export default function ListIndexView({ lists }: ListIndexViewProps) {
     <>
       <PageTitle title="リスト一覧" />
       <div className="mb-6 flex justify-end">
-        <Button variant="create" onClick={createModal.open} icon={<Plus className="h-4 w-4" />}>
+        <Button variant="primary" onClick={createModal.open} icon={<Plus className="h-4 w-4" />}>
           作成
         </Button>
       </div>

--- a/frontend/src/app/(protected)/lists/_components/form/index.tsx
+++ b/frontend/src/app/(protected)/lists/_components/form/index.tsx
@@ -49,7 +49,7 @@ export default function ListForm({ list, submitLabel, cancel }: ListFormProps) {
       />
 
       <div className="flex flex-col sm:flex-row justify-end gap-3">
-        <Button variant="cancel" onClick={cancel}>
+        <Button variant="secondary" onClick={cancel}>
           キャンセル
         </Button>
         <Button

--- a/frontend/src/app/(protected)/settings/_components/forms/EmailChangeForm.tsx
+++ b/frontend/src/app/(protected)/settings/_components/forms/EmailChangeForm.tsx
@@ -51,7 +51,7 @@ export default function EmailChangeForm({ currentEmail, onClose }: EmailChangeFo
             </p>
           </div>
           <div className="mt-6 flex justify-end gap-3">
-            <Button type="button" variant="cancel" onClick={onClose}>
+            <Button type="button" variant="secondary" onClick={onClose}>
               キャンセル
             </Button>
             <Button

--- a/frontend/src/app/(protected)/settings/_components/forms/NameForm.tsx
+++ b/frontend/src/app/(protected)/settings/_components/forms/NameForm.tsx
@@ -33,6 +33,9 @@ export default function NameForm({ user, onClose }: NameFormProps) {
       </div>
 
       <div className="flex justify-end gap-3">
+        <Button type="button" variant="secondary" onClick={onClose}>
+          キャンセル
+        </Button>
         <Button type="submit" variant="primary" disabled={isSubmitting} loadingLabel="更新中...">
           更新
         </Button>

--- a/frontend/src/app/(protected)/settings/_components/forms/PasswordChangeForm.tsx
+++ b/frontend/src/app/(protected)/settings/_components/forms/PasswordChangeForm.tsx
@@ -49,7 +49,7 @@ export default function PasswordChangeForm({ email, onClose }: PasswordChangeFor
             </p>
           </div>
           <div className="mt-6 flex justify-end gap-3">
-            <Button type="button" variant="cancel" onClick={onClose}>
+            <Button type="button" variant="secondary" onClick={onClose}>
               キャンセル
             </Button>
             <Button

--- a/frontend/src/app/(protected)/statuses/_components/forms/index.tsx
+++ b/frontend/src/app/(protected)/statuses/_components/forms/index.tsx
@@ -31,7 +31,7 @@ export default function StatusForm({ status, submitLabel, cancel }: StatusFormPr
       </div>
 
       <div className="flex justify-end gap-3">
-        <Button variant="cancel" onClick={cancel}>
+        <Button variant="secondary" onClick={cancel}>
           キャンセル
         </Button>
         <Button

--- a/frontend/src/app/(protected)/tags/_components/forms/index.tsx
+++ b/frontend/src/app/(protected)/tags/_components/forms/index.tsx
@@ -28,7 +28,7 @@ export default function TagForm({ tag, submitLabel, cancel }: TagFormProps) {
       </div>
 
       <div className="flex justify-end gap-3">
-        <Button variant="cancel" onClick={cancel}>
+        <Button variant="secondary" onClick={cancel}>
           キャンセル
         </Button>
         <Button

--- a/frontend/src/components/buttons/Button.test.tsx
+++ b/frontend/src/components/buttons/Button.test.tsx
@@ -57,51 +57,7 @@ describe('Button', () => {
     });
   });
 
-  describe('アクション系のスタイル', () => {
-    it('create 用のスタイルが適用される', () => {
-      render(
-        <Button variant="create" onClick={() => {}}>
-          テスト
-        </Button>,
-      );
-
-      expect(screen.getByRole('button')).toHaveClass('bg-primary text-white hover:bg-primary/90');
-    });
-
-    it('update 用のスタイルが適用される', () => {
-      render(
-        <Button variant="update" onClick={() => {}}>
-          テスト
-        </Button>,
-      );
-
-      expect(screen.getByRole('button')).toHaveClass('bg-green-600 text-white hover:bg-green-700');
-    });
-
-    it('delete 用のスタイルが適用される', () => {
-      render(
-        <Button variant="delete" onClick={() => {}}>
-          テスト
-        </Button>,
-      );
-
-      expect(screen.getByRole('button')).toHaveClass('bg-red-600 text-white hover:bg-red-700');
-    });
-
-    it('cancel 用のスタイルが適用される', () => {
-      render(
-        <Button variant="cancel" onClick={() => {}}>
-          テスト
-        </Button>,
-      );
-
-      expect(screen.getByRole('button')).toHaveClass(
-        'bg-slate-200 text-slate-800 hover:bg-slate-300',
-      );
-    });
-  });
-
-  describe('汎用スタイル', () => {
+  describe('バリアントスタイル', () => {
     it('primary 用のスタイルが適用される', () => {
       render(
         <Button variant="primary" onClick={() => {}}>
@@ -132,6 +88,18 @@ describe('Button', () => {
       );
 
       expect(screen.getByRole('button')).toHaveClass('text-red-600 hover:bg-red-500/10');
+    });
+
+    it('ghost 用のスタイルが適用される', () => {
+      render(
+        <Button variant="ghost" onClick={() => {}}>
+          テスト
+        </Button>,
+      );
+
+      expect(screen.getByRole('button')).toHaveClass(
+        'bg-transparent text-primary hover:bg-slate-100',
+      );
     });
   });
 });

--- a/frontend/src/components/buttons/Button.tsx
+++ b/frontend/src/components/buttons/Button.tsx
@@ -1,6 +1,6 @@
 interface ButtonProps {
   type?: 'button' | 'submit';
-  variant: 'create' | 'update' | 'delete' | 'cancel' | 'primary' | 'secondary' | 'danger';
+  variant: 'primary' | 'secondary' | 'danger' | 'ghost';
   onClick?: () => void;
   disabled?: boolean;
   children: React.ReactNode;
@@ -9,16 +9,10 @@ interface ButtonProps {
 }
 
 const BUTTON_STYLES = {
-  // アクション系（意味重視）
-  create: 'bg-primary text-white hover:bg-primary/90',
-  update: 'bg-green-600 text-white hover:bg-green-700',
-  delete: 'bg-red-600 text-white hover:bg-red-700',
-  cancel: 'bg-slate-200 text-slate-800 hover:bg-slate-300',
-
-  // 汎用（見た目重視）
   primary: 'bg-primary text-white hover:bg-primary/90',
   secondary: 'bg-slate-200 text-slate-800 hover:bg-slate-300',
   danger: 'text-red-600 hover:bg-red-500/10',
+  ghost: 'bg-transparent text-primary hover:bg-slate-100',
 };
 
 const BASE_STYLES =


### PR DESCRIPTION
## 概要
認証とカード関連機能のユニットテストを追加し、コンポーネント設計の改善とコードの保守性向上を実現しました。

## 主な変更内容

### ✅ テスト追加
- **認証関連**: useLogout, useLoginForm, useRegisterForm のユニットテストを追加
- **カード関連**: useCardItem, useCardForm のユニットテストを追加
- **認証UI**: LoginForm, RegisterForm のコンポーネントテストを追加

### 🔧 リファクタリング
- **useLogout**: 不要な try/catch を削除（エラーは戻り値で処理）
- **useRegisterForm**: エラー時に早期リターンを追加
- **認証API**: 戻り値を `{ success: true } | { error: string }` から `string | null` に統一
- **CardItem**: ロジックを useCardItem フックに分離（UIとロジックの完全分離）
- **Button**: バリアントを8つから4つ（primary/secondary/danger/ghost）に整理

### 🎨 UI改善
- Button の ghost バリアントを追加（軽量なテキストリンク風ボタン）
- NameForm にキャンセルボタンを追加（UX向上）

## テスト戦略
- React Hook のモック戦略を確立（useRouter, useQueryClient など）
- TanStack Query の useMutation コールバックテストのパターンを確立
- mockResolvedValue を使用したエラーハンドリングテスト

## 影響範囲
- 認証フロー（ログイン・登録・ログアウト）
- カード作成・編集・削除機能
- Button コンポーネントを使用する全ページ（11ファイル）

## テスト実行結果
全テストが成功することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)