### PR TITLE
feat: ユーザーアバターのアップロード機能を実装

### DIFF
--- a/backend/app/controllers/api/profiles_controller.rb
+++ b/backend/app/controllers/api/profiles_controller.rb
@@ -24,7 +24,7 @@ module Api
     private
 
     def profile_params
-      params.require(:profile).permit(:name, :avatar_url)
+      params.require(:profile).permit(:name, :avatar_url, :avatar_public_id)
     end
 
     def record_not_found

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ApplicationRecord
 
   validates :name, presence: true, length: { maximum: 50 }
   validates :supabase_uid, presence: true, uniqueness: true
+  validates :avatar_url, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]), message: 'must be a valid URL' }, allow_nil: true
 
   # 初回ログイン時にSupabaseのUIDをもとにユーザーを検索し、存在しない場合は作成する
   def self.find_or_create_by_supabase_uid(supabase_uid, payload = {})

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -14,7 +14,10 @@ class User < ApplicationRecord
 
   validates :name, presence: true, length: { maximum: 50 }
   validates :supabase_uid, presence: true, uniqueness: true
-  validates :avatar_url, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]), message: 'must be a valid URL' }, allow_nil: true
+  validates :avatar_url,
+            format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]),
+                      message: 'must be a valid URL' },
+            allow_nil: true
 
   # 初回ログイン時にSupabaseのUIDをもとにユーザーを検索し、存在しない場合は作成する
   def self.find_or_create_by_supabase_uid(supabase_uid, payload = {})

--- a/backend/db/migrate/20260115172632_add_avatar_public_id_to_users.rb
+++ b/backend/db/migrate/20260115172632_add_avatar_public_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddAvatarPublicIdToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :avatar_public_id, :string
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_01_13_155828) do
+ActiveRecord::Schema[7.1].define(version: 2026_01_15_172632) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -114,6 +114,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_01_13_155828) do
     t.string "avatar_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "avatar_public_id"
     t.index ["supabase_uid"], name: "index_users_on_supabase_uid", unique: true
   end
 

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -8,6 +8,29 @@ RSpec.describe User, type: :model do
     it { is_expected.to validate_length_of(:name).is_at_most(50) }
     it { is_expected.to validate_presence_of(:supabase_uid) }
     it { is_expected.to validate_uniqueness_of(:supabase_uid) }
+
+    context 'avatar_url' do
+      it 'nilの場合は有効であること' do
+        user.avatar_url = nil
+        expect(user).to be_valid
+      end
+
+      it '有効なURL形式の場合は有効であること' do
+        user.avatar_url = 'https://example.com/avatar.jpg'
+        expect(user).to be_valid
+      end
+
+      it '無効なURL形式の場合は無効であること' do
+        user.avatar_url = 'invalid-url'
+        expect(user).not_to be_valid
+        expect(user.errors[:avatar_url]).to include('must be a valid URL')
+      end
+
+      it 'httpスキームのURLは有効であること' do
+        user.avatar_url = 'http://example.com/avatar.jpg'
+        expect(user).to be_valid
+      end
+    end
   end
 
   describe 'アソシエーション' do

--- a/backend/spec/requests/api/profiles_spec.rb
+++ b/backend/spec/requests/api/profiles_spec.rb
@@ -41,6 +41,27 @@ RSpec.describe 'Api::Profiles', type: :request do
       expect(user.reload.name).to eq('新しい名前')
     end
 
+    it 'avatar_urlをnullにして画像を削除できること' do
+      user.update(avatar_url: 'https://example.com/old-avatar.jpg')
+
+      patch '/api/profile',
+            params: { profile: { avatar_url: nil } },
+            headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.avatar_url).to be_nil
+    end
+
+    it '無効なURLの場合は更新できないこと' do
+      patch '/api/profile',
+            params: { profile: { avatar_url: 'invalid-url' } },
+            headers: headers
+
+      expect(response).to have_http_status(:unprocessable_content)
+      json = response.parsed_body
+      expect(json['code']).to eq('UPDATE_FAILED')
+    end
+
     it '名前が空の場合は更新できないこと' do
       patch '/api/profile',
             params: { profile: { name: '' } },

--- a/backend/spec/requests/api/profiles_spec.rb
+++ b/backend/spec/requests/api/profiles_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe 'Api::Profiles', type: :request do
       {
         profile: {
           name: '新しい名前',
-          avatar_url: 'https://example.com/avatar.jpg'
+          avatar_url: 'https://example.com/avatar.jpg',
+          avatar_public_id: 'avatars/test123'
         }
       }
     end
@@ -38,18 +39,21 @@ RSpec.describe 'Api::Profiles', type: :request do
       json = response.parsed_body
       expect(json['name']).to eq('新しい名前')
       expect(json['avatar_url']).to eq('https://example.com/avatar.jpg')
+      expect(json['avatar_public_id']).to eq('avatars/test123')
       expect(user.reload.name).to eq('新しい名前')
+      expect(user.reload.avatar_public_id).to eq('avatars/test123')
     end
 
     it 'avatar_urlをnullにして画像を削除できること' do
-      user.update(avatar_url: 'https://example.com/old-avatar.jpg')
+      user.update(avatar_url: 'https://example.com/old-avatar.jpg', avatar_public_id: 'avatars/old123')
 
       patch '/api/profile',
-            params: { profile: { avatar_url: nil } },
+            params: { profile: { avatar_url: nil, avatar_public_id: nil } },
             headers: headers
 
       expect(response).to have_http_status(:ok)
       expect(user.reload.avatar_url).to be_nil
+      expect(user.reload.avatar_public_id).to be_nil
     end
 
     it '無効なURLの場合は更新できないこと' do

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -10,6 +10,12 @@ const nextConfig: NextConfig = {
         port: '',
         pathname: '/books/content/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'res.cloudinary.com',
+        port: '',
+        pathname: '/**',
+      },
     ],
   },
   async headers() {
@@ -21,11 +27,12 @@ const nextConfig: NextConfig = {
             key: 'Content-Security-Policy',
             value: [
               "default-src 'self'",
-              "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
+              "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://upload-widget.cloudinary.com https://widget.cloudinary.com",
               "style-src 'self' 'unsafe-inline'",
               "img-src 'self' data: https: http:",
               "font-src 'self' data:",
-              "connect-src 'self' https://*.supabase.co https://www.googleapis.com",
+              "connect-src 'self' https://*.supabase.co https://www.googleapis.com https://api.cloudinary.com https://*.cloudinary.com",
+              'frame-src https://upload-widget.cloudinary.com',
               "frame-ancestors 'none'",
               "base-uri 'self'",
               "form-action 'self'",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@tanstack/react-query": "^5.90.5",
         "lucide-react": "^0.545.0",
         "next": "^16.0.7",
+        "next-cloudinary": "^6.17.5",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
         "react-hook-form": "^7.65.0",
@@ -142,6 +143,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -450,6 +452,63 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@cloudinary-util/types": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/@cloudinary-util/types/-/types-1.5.10.tgz",
+      "integrity": "sha512-n5lrm7SdAXhgWEbkSJKHZGnaoO9G/g4WYS6HYnq/k4nLj79sYfQZOoKjyR8hF2iyLRdLkT+qlk68RNFFv5tKew==",
+      "license": "MIT"
+    },
+    "node_modules/@cloudinary-util/url-loader": {
+      "version": "5.10.4",
+      "resolved": "https://registry.npmjs.org/@cloudinary-util/url-loader/-/url-loader-5.10.4.tgz",
+      "integrity": "sha512-gHkdvOaV+rlcwuIT7Vqd0ts/H5bsH4+bwFten/gIZ8oRjzdTBvgIY3R6F8bbJt0pFIEfpFEQLe4rPkl0NNqEWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudinary-util/types": "1.5.10",
+        "@cloudinary-util/util": "3.3.2",
+        "@cloudinary/url-gen": "1.15.0",
+        "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@cloudinary-util/url-loader/node_modules/@cloudinary-util/util": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@cloudinary-util/util/-/util-3.3.2.tgz",
+      "integrity": "sha512-Cc0iFxzfl7fcOXuznpeZFGYC885Of/vDgccRDnhTe/8Rf8YKv2PjLtezyo0VgmdA/CpeZy29NCXAsf6liokbwg==",
+      "license": "MIT"
+    },
+    "node_modules/@cloudinary-util/url-loader/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@cloudinary-util/util": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@cloudinary-util/util/-/util-4.0.0.tgz",
+      "integrity": "sha512-S4xcou/3A7l5o+bcKlw2VHBNgwups7/0lbVDT/cO5YmtrcEYXgj6LGmwnjvpTm/x571VPVN8x5jWdT3rLZiKJQ==",
+      "license": "MIT"
+    },
+    "node_modules/@cloudinary/transformation-builder-sdk": {
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@cloudinary/transformation-builder-sdk/-/transformation-builder-sdk-1.21.2.tgz",
+      "integrity": "sha512-ehOgKUaP+Nvuf7B0TosmB8iilL0kdiVjzjl8tIK06cjvsNnwSJI3xP9nEJmKkvqNxwwFwvYXT+mxUTqnSv9JOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudinary/url-gen": "^1.7.0"
+      }
+    },
+    "node_modules/@cloudinary/url-gen": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@cloudinary/url-gen/-/url-gen-1.15.0.tgz",
+      "integrity": "sha512-bjU67eZxLUgoRy/Plli4TQio7q6P31OYqnEgXxeN9TKXrzr6h0DeEdIUhKI9gy3HkEBWXWWJIPh7j7gkOJPnyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudinary/transformation-builder-sdk": "^1.10.0"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
@@ -538,6 +597,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -581,6 +641,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2297,6 +2358,7 @@
       "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.57.0"
       },
@@ -2865,6 +2927,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.75.0.tgz",
       "integrity": "sha512-8UN/vATSgS2JFuJlMVr51L3eUDz+j1m7Ww63wlvHLKULzCDaVWYzvacCjBTLW/lX/vedI2LBI4Vg+01G9ufsJQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.75.0",
         "@supabase/functions-js": "2.75.0",
@@ -3185,6 +3248,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.5.tgz",
       "integrity": "sha512-pN+8UWpxZkEJ/Rnnj2v2Sxpx1WFlaa9L6a4UO89p6tTQbeo+m0MS8oYDjbggrR8QcTyjKoYWKS3xJQGr3ExT8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.5"
       },
@@ -3268,7 +3332,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3358,8 +3421,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3534,6 +3596,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3544,6 +3607,7 @@
       "integrity": "sha512-/EEvYBdT3BflCWvTMO7YkYBHVE9Ci6XdqZciZANQgKpaiDRGOLIlRo91jbTNRQjgPFWVaRxcYc0luVNFitz57A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3625,6 +3689,7 @@
       "integrity": "sha512-n1H6IcDhmmUEG7TNVSspGmiHHutt7iVKtZwRppD7e04wha5MrkV1h3pti9xQLcCMt6YWsncpoT0HMjkH1FNwWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.0",
         "@typescript-eslint/types": "8.46.0",
@@ -4233,6 +4298,7 @@
       "integrity": "sha512-F9jI5rSstNknPlTlPN2gcc4gpbaagowuRzw/OJzl368dvPun668Q182S8Q8P9PITgGCl5LAKXpzuue106eM4wA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.8",
         "fflate": "^0.8.2",
@@ -4269,6 +4335,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4665,6 +4732,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -4975,7 +5043,8 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -5289,7 +5358,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5322,8 +5390,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -5677,6 +5744,7 @@
       "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5766,6 +5834,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5867,6 +5936,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7820,7 +7890,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7961,6 +8030,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.40.0",
@@ -8100,6 +8170,21 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-cloudinary": {
+      "version": "6.17.5",
+      "resolved": "https://registry.npmjs.org/next-cloudinary/-/next-cloudinary-6.17.5.tgz",
+      "integrity": "sha512-YIyIWw5Ds30f4rnED+E9ssLUd94FOPTtbkO2KUvOcw9z4irOEIpb1goxMxbn2EUBnIGQOd6uUf1gFizjME7pMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudinary-util/types": "1.5.10",
+        "@cloudinary-util/url-loader": "5.10.4",
+        "@cloudinary-util/util": "4.0.0"
+      },
+      "peerDependencies": {
+        "next": "^12 || ^13 || ^14 || >=15.0.0-rc || ^15",
+        "react": "^17 || ^18 || >=19.0.0-beta || ^19"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -8547,6 +8632,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8576,7 +8662,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8592,7 +8677,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8605,8 +8689,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -8655,6 +8738,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8664,6 +8748,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8676,6 +8761,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.65.0.tgz",
       "integrity": "sha512-xtOzDz063WcXvGWaHgLNrNzlsdFgtUWcb32E6WFaGTd7kPZG3EeDusjdZfUsPwKCKVXy1ZlntifaHZ4l8pAsmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -8708,13 +8794,15 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -8828,7 +8916,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -9801,6 +9890,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10025,6 +10115,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10195,6 +10286,7 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -10288,6 +10380,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10301,6 +10394,7 @@
       "integrity": "sha512-urzu3NCEV0Qa0Y2PwvBtRgmNtxhj5t5ULw7cuKhIHh3OrkKTLlut0lnBOv9qe5OvbkMH2g38G7KPDCTpIytBVg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.8",
         "@vitest/mocker": "4.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "@tanstack/react-query": "^5.90.5",
     "lucide-react": "^0.545.0",
     "next": "^16.0.7",
+    "next-cloudinary": "^6.17.5",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "react-hook-form": "^7.65.0",

--- a/frontend/src/app/(protected)/settings/_components/display/AvatarUpload.test.tsx
+++ b/frontend/src/app/(protected)/settings/_components/display/AvatarUpload.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { createProvider } from '@/test/helpers';
+import { createMockUser } from '@/test/factories';
+import AvatarUpload from './AvatarUpload';
+
+// next-cloudinaryをモック
+vi.mock('next-cloudinary', () => ({
+  CldUploadWidget: ({ children }: { children: (props: { open: () => void }) => React.ReactNode }) =>
+    children({ open: vi.fn() }),
+}));
+
+// 環境変数をモック
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME = 'test-cloud';
+  process.env.NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET = 'test-preset';
+});
+
+describe('AvatarUpload', () => {
+  describe('環境変数が設定されている場合', () => {
+    it('アバター画像がない場合、アイコンとアップロードボタンが表示される', () => {
+      const user = createMockUser({ avatar_url: null });
+
+      render(<AvatarUpload user={user} />, { wrapper: createProvider() });
+
+      // アップロードボタンが表示される
+      expect(screen.getByRole('button', { name: /画像をアップロード/i })).toBeInTheDocument();
+      // 削除ボタンは表示されない
+      expect(screen.queryByRole('button', { name: /削除/i })).not.toBeInTheDocument();
+    });
+
+    it('アバター画像がある場合、画像と変更・削除ボタンが表示される', () => {
+      const user = createMockUser({ avatar_url: 'https://example.com/avatar.jpg' });
+
+      render(<AvatarUpload user={user} />, { wrapper: createProvider() });
+
+      // 変更ボタンが表示される
+      expect(screen.getByRole('button', { name: /画像を変更/i })).toBeInTheDocument();
+      // 削除ボタンが表示される
+      expect(screen.getByRole('button', { name: /削除/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('環境変数が設定されていない場合', () => {
+    it('何も表示されない', () => {
+      process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME = '';
+      process.env.NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET = '';
+
+      const user = createMockUser({ avatar_url: null });
+
+      const { container } = render(<AvatarUpload user={user} />, { wrapper: createProvider() });
+
+      expect(container.firstChild).toBeNull();
+    });
+  });
+});

--- a/frontend/src/app/(protected)/settings/_components/display/AvatarUpload.tsx
+++ b/frontend/src/app/(protected)/settings/_components/display/AvatarUpload.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { User as UserIcon, Upload, Trash2 } from 'lucide-react';
+import { CldUploadWidget, CldImage } from 'next-cloudinary';
+import { User } from '@/schemas/user';
+import { useAvatarUpload } from '@/app/(protected)/settings/_hooks/useAvatarUpload';
+import Button from '@/components/buttons/Button';
+
+interface AvatarUploadProps {
+  user: User;
+}
+
+export default function AvatarUpload({ user }: AvatarUploadProps) {
+  const { isUploading, handleUploadSuccess, handleUploadError, handleDelete, setIsUploading } =
+    useAvatarUpload({ user });
+
+  const cloudName = process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME;
+  const uploadPreset = process.env.NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET;
+
+  if (!cloudName || !uploadPreset) {
+    console.error('Cloudinary環境変数が設定されていません');
+    return null;
+  }
+
+  return (
+    <div className="mb-8 flex flex-col items-center gap-4">
+      {/* アバター画像 */}
+      <div className="relative h-24 w-24 flex-shrink-0">
+        {user.avatar_public_id ? (
+          <CldImage
+            src={user.avatar_public_id}
+            alt={user.name}
+            width={96}
+            height={96}
+            crop="thumb"
+            gravity="custom"
+            className="rounded-full object-cover"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center rounded-full bg-gray-100">
+            <UserIcon className="h-12 w-12 text-gray-400" />
+          </div>
+        )}
+      </div>
+
+      {/* アクションボタン */}
+      <div className="flex gap-2">
+        <CldUploadWidget
+          uploadPreset={uploadPreset}
+          options={{
+            sources: ['local', 'camera'],
+            multiple: false,
+            maxFiles: 1,
+            folder: 'avatars',
+            clientAllowedFormats: ['png', 'jpg', 'jpeg', 'gif', 'webp'],
+            maxFileSize: 5000000, // 5MB
+            cropping: true,
+            croppingAspectRatio: 1,
+            croppingShowDimensions: true,
+            croppingCoordinatesMode: 'custom',
+            showSkipCropButton: false,
+          }}
+          onSuccess={(result) => {
+            if (typeof result.info === 'object' && 'secure_url' in result.info) {
+              handleUploadSuccess(result.info);
+            }
+          }}
+          onError={handleUploadError}
+          onOpen={() => setIsUploading(true)}
+          onClose={() => setIsUploading(false)}
+        >
+          {({ open }) => (
+            <Button
+              variant="secondary"
+              onClick={() => open()}
+              icon={<Upload size={18} />}
+              disabled={isUploading}
+              loadingLabel="アップロード中..."
+            >
+              {user.avatar_url ? '画像を変更' : '画像をアップロード'}
+            </Button>
+          )}
+        </CldUploadWidget>
+
+        {user.avatar_url && (
+          <Button
+            variant="danger"
+            onClick={handleDelete}
+            icon={<Trash2 size={18} />}
+            disabled={isUploading}
+          >
+            削除
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(protected)/settings/_components/display/view/SettingsView.tsx
+++ b/frontend/src/app/(protected)/settings/_components/display/view/SettingsView.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import Image from 'next/image';
-import { User as UserIcon } from 'lucide-react';
 import { User } from '@/schemas/user';
 import { useModal } from '@/hooks/useModal';
 import SettingsItem from '@/app/(protected)/settings/_components/display/SettingsItem';
+import AvatarUpload from '@/app/(protected)/settings/_components/display/AvatarUpload';
 import UserFormModal from '@/app/(protected)/settings/_components/modal/UserFormModal';
 import PasswordChangeModal from '@/app/(protected)/settings/_components/modal/PasswordChangeModal';
 import EmailChangeModal from '@/app/(protected)/settings/_components/modal/EmailChangeModal';
@@ -24,22 +23,7 @@ export default function SettingsView({ email, user }: SettingsViewProps) {
       <h2 className="mb-6 text-xl font-semibold text-gray-900">プロフィール情報</h2>
 
       {/* アバター */}
-      <div className="mb-8 flex justify-center">
-        <div className="relative h-24 w-24 flex-shrink-0">
-          {user.avatar_url ? (
-            <Image
-              src={user.avatar_url}
-              alt={user.name}
-              fill
-              className="rounded-full object-cover"
-            />
-          ) : (
-            <div className="flex h-full w-full items-center justify-center rounded-full bg-gray-100">
-              <UserIcon className="h-12 w-12 text-gray-400" />
-            </div>
-          )}
-        </div>
-      </div>
+      <AvatarUpload user={user} />
 
       <div className="space-y-6">
         <SettingsItem label="名前" value={user.name} onEdit={updateNameModal.open} />

--- a/frontend/src/app/(protected)/settings/_hooks/useAvatarUpload.test.tsx
+++ b/frontend/src/app/(protected)/settings/_hooks/useAvatarUpload.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { createProvider } from '@/test/helpers';
+import { createMockUser } from '@/test/factories';
+import { mockUseProfileMutations } from '@/test/mocks';
+import { useAvatarUpload } from './useAvatarUpload';
+import toast from 'react-hot-toast';
+
+// ミューテーションをモック
+vi.mock('@/app/(protected)/settings/_hooks/useProfileMutations');
+
+// react-hot-toastをモック
+vi.mock('react-hot-toast', () => ({
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('useAvatarUpload', () => {
+  const mockUser = createMockUser({
+    name: 'テストユーザー',
+    avatar_url: 'https://example.com/avatar.jpg',
+  });
+
+  const mockUpdate = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseProfileMutations({ updateUser: mockUpdate });
+  });
+
+  describe('handleUploadSuccess', () => {
+    it('アップロード成功時にプロフィールを更新する', async () => {
+      const mockResult = {
+        secure_url: 'https://cloudinary.com/new-avatar.jpg',
+        public_id: 'avatars/test123',
+      };
+
+      const { result } = renderHook(() => useAvatarUpload({ user: mockUser }), {
+        wrapper: createProvider(),
+      });
+
+      expect(result.current.isUploading).toBe(false);
+
+      act(() => {
+        result.current.handleUploadSuccess(mockResult);
+      });
+
+      expect(mockUpdate).toHaveBeenCalledWith({
+        name: mockUser.name,
+        avatar_url: mockResult.secure_url,
+        avatar_public_id: mockResult.public_id,
+      });
+
+      expect(result.current.isUploading).toBe(false);
+    });
+  });
+
+  describe('handleUploadError', () => {
+    it('アップロード失敗時にエラーメッセージを表示する', () => {
+      const { result } = renderHook(() => useAvatarUpload({ user: mockUser }), {
+        wrapper: createProvider(),
+      });
+
+      act(() => {
+        result.current.setIsUploading(true);
+      });
+
+      expect(result.current.isUploading).toBe(true);
+
+      act(() => {
+        result.current.handleUploadError();
+      });
+
+      expect(result.current.isUploading).toBe(false);
+      expect(toast.error).toHaveBeenCalledWith('画像のアップロードに失敗しました');
+    });
+  });
+
+  describe('handleDelete', () => {
+    it('削除時にavatar_urlをnullにしてプロフィールを更新する', async () => {
+      const { result } = renderHook(() => useAvatarUpload({ user: mockUser }), {
+        wrapper: createProvider(),
+      });
+
+      act(() => {
+        result.current.handleDelete();
+      });
+
+      expect(mockUpdate).toHaveBeenCalledWith({
+        name: mockUser.name,
+        avatar_url: null,
+        avatar_public_id: null,
+      });
+
+      expect(result.current.isUploading).toBe(false);
+    });
+  });
+
+  describe('isUploading', () => {
+    it('アップロード中またはプロフィール更新中の場合trueになる', () => {
+      const { result } = renderHook(() => useAvatarUpload({ user: mockUser }), {
+        wrapper: createProvider(),
+      });
+
+      expect(result.current.isUploading).toBe(false);
+
+      act(() => {
+        result.current.setIsUploading(true);
+      });
+
+      expect(result.current.isUploading).toBe(true);
+    });
+  });
+});

--- a/frontend/src/app/(protected)/settings/_hooks/useAvatarUpload.ts
+++ b/frontend/src/app/(protected)/settings/_hooks/useAvatarUpload.ts
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { User } from '@/schemas/user';
+import { useProfileMutations } from '@/app/(protected)/settings/_hooks/useProfileMutations';
+import toast from 'react-hot-toast';
+
+interface CloudinaryUploadResponse {
+  secure_url: string;
+  public_id: string;
+}
+
+interface UseAvatarUploadProps {
+  user: User;
+}
+
+export function useAvatarUpload({ user }: UseAvatarUploadProps) {
+  const [isUploading, setIsUploading] = useState(false);
+  const { updateUser, isUpdating } = useProfileMutations();
+
+  const handleUploadSuccess = (result: CloudinaryUploadResponse) => {
+    setIsUploading(false);
+    const avatarUrl = result.secure_url;
+    const avatarPublicId = result.public_id;
+
+    // プロフィールを更新（nameは必須なので含める）
+    updateUser({ name: user.name, avatar_url: avatarUrl, avatar_public_id: avatarPublicId });
+  };
+
+  const handleUploadError = () => {
+    setIsUploading(false);
+    toast.error('画像のアップロードに失敗しました');
+  };
+
+  const handleDelete = () => {
+    // avatar_urlとavatar_public_idをnullにして削除
+    updateUser({ name: user.name, avatar_url: null, avatar_public_id: null });
+  };
+
+  return {
+    isUploading: isUploading || isUpdating,
+    handleUploadSuccess,
+    handleUploadError,
+    handleDelete,
+    setIsUploading,
+  };
+}

--- a/frontend/src/app/(protected)/users/_components/display/view/UserProfileView.test.tsx
+++ b/frontend/src/app/(protected)/users/_components/display/view/UserProfileView.test.tsx
@@ -83,7 +83,7 @@ describe('UserProfileView', () => {
     it('プロフィール画像が存在する場合、画像が表示される', () => {
       const user = createMockUserWithStats({
         name: 'テストユーザー',
-        avatar_url: 'http://testImage.com',
+        avatar_public_id: 'avatars/test123',
       });
 
       render(<UserProfileView user={user} />, { wrapper: createProvider() });
@@ -92,7 +92,7 @@ describe('UserProfileView', () => {
     });
 
     it('プロフィール画像が無い場合、ユーザー名の頭文字が表示される', () => {
-      const user = createMockUserWithStats({ name: 'テストユーザー' });
+      const user = createMockUserWithStats({ name: 'テストユーザー', avatar_public_id: null });
 
       render(<UserProfileView user={user} />, { wrapper: createProvider() });
 

--- a/frontend/src/app/(protected)/users/_components/display/view/UserProfileView.tsx
+++ b/frontend/src/app/(protected)/users/_components/display/view/UserProfileView.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import Image from 'next/image';
 import Link from 'next/link';
 import { BookOpen, List, Users, UserCheck } from 'lucide-react';
+import { CldImage } from 'next-cloudinary';
 import { UserWithStats } from '@/app/(protected)/users/_types';
 import FollowButton from '@/app/(protected)/users/_components/actions/FollowButton';
 
@@ -17,12 +17,14 @@ export default function UserProfileView({ user }: UserProfileViewProps) {
       <div className="bg-white rounded-lg border border-slate-200 p-8">
         <div className="flex flex-col items-center">
           {/* プロフィール画像 or 頭文字 */}
-          {user.avatar_url ? (
-            <Image
-              src={user.avatar_url}
+          {user.avatar_public_id ? (
+            <CldImage
+              src={user.avatar_public_id}
               alt={user.name}
               width={128}
               height={128}
+              crop="thumb"
+              gravity="custom"
               className="w-32 h-32 rounded-full object-cover mb-4"
             />
           ) : (

--- a/frontend/src/app/(protected)/users/_lib/query/fetchFollowers.test.ts
+++ b/frontend/src/app/(protected)/users/_lib/query/fetchFollowers.test.ts
@@ -15,6 +15,7 @@ describe('fetchFollowers', () => {
           supabase_uid: '1',
           name: 'テストユーザー',
           avatar_url: null,
+          avatar_public_id: null,
           created_at: '2025/1/1 9:00:00',
           updated_at: '2025/1/1 9:00:00',
         },

--- a/frontend/src/app/(protected)/users/_lib/query/fetchFollowing.test.ts
+++ b/frontend/src/app/(protected)/users/_lib/query/fetchFollowing.test.ts
@@ -15,6 +15,7 @@ describe('fetchFollowing', () => {
           supabase_uid: '1',
           name: 'テストユーザー',
           avatar_url: null,
+          avatar_public_id: null,
           created_at: '2025/1/1 9:00:00',
           updated_at: '2025/1/1 9:00:00',
         },

--- a/frontend/src/app/(protected)/users/search/_components/UserSearchResults.tsx
+++ b/frontend/src/app/(protected)/users/search/_components/UserSearchResults.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { CldImage } from 'next-cloudinary';
 import { UserSearchResult } from '@/app/(protected)/users/_types';
 import FollowButton from '@/app/(protected)/users/_components/actions/FollowButton';
 
@@ -41,12 +42,25 @@ export default function UserSearchResults({
               className="p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
             >
               <div className="flex items-center gap-3">
-                {/* TODO: ユーザー画像変更機能実装後に画像を表示するように変更 */}
-                <div
-                  className="w-10 h-10 rounded-full bg-blue-500 flex items-center justify-center text-white font-medium cursor-pointer"
-                  data-testid="initial"
-                >
-                  {user.name.charAt(0).toUpperCase()}
+                <div className="relative w-10 h-10 flex-shrink-0">
+                  {user.avatar_public_id ? (
+                    <CldImage
+                      src={user.avatar_public_id}
+                      alt={user.name}
+                      width={40}
+                      height={40}
+                      crop="thumb"
+                      gravity="custom"
+                      className="rounded-full object-cover"
+                    />
+                  ) : (
+                    <div
+                      className="w-10 h-10 rounded-full bg-blue-500 flex items-center justify-center text-white font-medium"
+                      data-testid="initial"
+                    >
+                      {user.name.charAt(0).toUpperCase()}
+                    </div>
+                  )}
                 </div>
                 <Link href={`/users/${user.id}`} className="flex-1 min-w-0">
                   <div className="font-medium text-gray-900 truncate hover:underline">

--- a/frontend/src/components/navigation/SideNav.tsx
+++ b/frontend/src/components/navigation/SideNav.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useState } from 'react';
 import { Menu, X } from 'lucide-react';
+import { CldImage } from 'next-cloudinary';
 import { NAV_ITEMS } from '@/constants/navItems';
 import { useProfile } from '@/hooks/useProfile';
 
@@ -41,8 +42,22 @@ export default function SideNav() {
         <div className="flex flex-col gap-4 pt-16 lg:pt-0">
           {/* ユーザープロフィール */}
           <div className="flex items-center gap-3">
-            <div className="flex size-10 items-center justify-center rounded-full bg-primary text-white font-bold">
-              {profile?.name?.charAt(0).toUpperCase() || '?'}
+            <div className="relative size-10 flex-shrink-0">
+              {profile?.avatar_public_id ? (
+                <CldImage
+                  src={profile.avatar_public_id}
+                  alt={profile.name}
+                  width={40}
+                  height={40}
+                  crop="thumb"
+                  gravity="custom"
+                  className="rounded-full object-cover"
+                />
+              ) : (
+                <div className="flex size-10 items-center justify-center rounded-full bg-primary text-white font-bold">
+                  {profile?.name?.charAt(0).toUpperCase() || '?'}
+                </div>
+              )}
             </div>
             <div className="flex flex-col">
               <h1 className="text-slate-900 text-base font-medium leading-normal">

--- a/frontend/src/schemas/user.test.ts
+++ b/frontend/src/schemas/user.test.ts
@@ -202,6 +202,7 @@ describe('userWithStatsSchema', () => {
         supabase_uid: 'test-uid-123',
         name: 'テストユーザー',
         avatar_url: null,
+        avatar_public_id: null,
         created_at: '2025-01-01T00:00:00.000+09:00',
         updated_at: '2025-01-01T00:00:00.000+09:00',
         stats: {
@@ -226,6 +227,7 @@ describe('userWithStatsSchema', () => {
         supabase_uid: 'test-uid-123',
         name: 'テストユーザー',
         avatar_url: null,
+        avatar_public_id: null,
         created_at: '2025-01-01T00:00:00.000+09:00',
         updated_at: '2025-01-01T00:00:00.000+09:00',
         stats: {

--- a/frontend/src/schemas/user.ts
+++ b/frontend/src/schemas/user.ts
@@ -5,6 +5,7 @@ export const userSchema = z.object({
   supabase_uid: z.string(),
   name: z.string(),
   avatar_url: z.string().nullable(),
+  avatar_public_id: z.string().nullable(),
   created_at: z.string().transform((str) => {
     return new Date(str).toLocaleString('ja-JP', {
       timeZone: 'Asia/Tokyo',
@@ -35,6 +36,7 @@ export const userSearchResultSchema = z.object({
   id: z.string(),
   name: z.string(),
   avatar_url: z.string().nullable(),
+  avatar_public_id: z.string().nullable(),
 });
 
 export const followStatusSchema = z.object({
@@ -49,7 +51,8 @@ export const userFormSchema = z.object({
     .trim()
     .min(1, { message: 'ユーザー名を入力してください' })
     .max(50, { message: 'ユーザー名は50文字以内で入力してください' }),
-  avatar_url: z.string().optional(),
+  avatar_url: z.string().nullable().optional(),
+  avatar_public_id: z.string().nullable().optional(),
 });
 
 export type User = z.infer<typeof userSchema>;

--- a/frontend/src/test/factories/user.ts
+++ b/frontend/src/test/factories/user.ts
@@ -10,6 +10,7 @@ export const createMockUser = (overrides?: Partial<User>): User => ({
   supabase_uid: '1',
   name: 'テストユーザー',
   avatar_url: null,
+  avatar_public_id: null,
   created_at: '2025-01-01T00:00:00Z',
   updated_at: '2025-01-01T00:00:00Z',
   ...overrides,
@@ -25,6 +26,7 @@ export const createMockUserWithStats = (overrides?: Partial<UserWithStats>): Use
   supabase_uid: '1',
   name: 'テストユーザー',
   avatar_url: null,
+  avatar_public_id: null,
   created_at: '2025-01-01T00:00:00Z',
   updated_at: '2025-01-01T00:00:00Z',
   stats: {

--- a/frontend/src/test/mocks/handlers/profile.ts
+++ b/frontend/src/test/mocks/handlers/profile.ts
@@ -10,12 +10,17 @@ export const profileHandlers = [
   // PUT - プロフィール更新
   http.put('/api/profiles', async ({ request }) => {
     const body = await request.json();
-    const { name, avatar_url } = body as { name?: string; avatar_url?: string | null };
+    const { name, avatar_url, avatar_public_id } = body as {
+      name?: string;
+      avatar_url?: string | null;
+      avatar_public_id?: string | null;
+    };
 
     return HttpResponse.json(
       createMockUser({
         name: name ?? 'テストユーザー',
         avatar_url: avatar_url ?? null,
+        avatar_public_id: avatar_public_id ?? null,
       }),
     );
   }),

--- a/frontend/src/test/mocks/index.ts
+++ b/frontend/src/test/mocks/index.ts
@@ -7,3 +7,4 @@ export { mockUseCardMutations } from './mockCardHooks';
 export { mockUseCategoryMutations } from './mockCategoryHooks';
 export { mockUseListMutations } from './mockListHooks';
 export { mockUseTagMutations } from './mockTagHooks';
+export { mockUseProfileMutations } from './mockProfileHooks';

--- a/frontend/src/test/mocks/mockProfileHooks.ts
+++ b/frontend/src/test/mocks/mockProfileHooks.ts
@@ -1,0 +1,11 @@
+import { vi } from 'vitest';
+import { useProfileMutations } from '@/app/(protected)/settings/_hooks/useProfileMutations';
+
+export const mockUseProfileMutations = (overrides = {}) => {
+  vi.mocked(useProfileMutations).mockReturnValue({
+    updateUser: vi.fn(),
+    isUpdating: false,
+    updateError: null,
+    ...overrides
+  });
+};

--- a/frontend/src/test/mocks/mockProfileHooks.ts
+++ b/frontend/src/test/mocks/mockProfileHooks.ts
@@ -6,6 +6,6 @@ export const mockUseProfileMutations = (overrides = {}) => {
     updateUser: vi.fn(),
     isUpdating: false,
     updateError: null,
-    ...overrides
+    ...overrides,
   });
 };

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -2,6 +2,10 @@ import '@testing-library/jest-dom/vitest';
 import { server } from './mocks/server';
 import { beforeAll, afterEach, afterAll } from 'vitest';
 
+// Cloudinary環境変数のモック
+process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME = 'test-cloud-name';
+process.env.NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET = 'test-upload-preset';
+
 // MSWサーバーのセットアップ
 beforeAll(() => {
   server.listen({ onUnhandledRequest: 'warn' });


### PR DESCRIPTION
## 概要
Cloudinaryを使用したユーザーアバターのアップロード・表示機能を実装

## 詳細
- usersテーブルに`avatar_public_id`カラムを追加
- next-cloudinaryパッケージを導入し、CldUploadWidgetでアップロード、CldImageで表示
- 設定画面にアバターアップロードUIを追加（クロップ機能付き）
- SideNav、UserProfileView、UserSearchResultsでアバター表示に対応

## 関連Issue
Closes #151