### PR TITLE
feat: Google OAuthログイン機能を実装

### DIFF
--- a/frontend/e2e/about.spec.ts
+++ b/frontend/e2e/about.spec.ts
@@ -69,7 +69,7 @@ test.describe('アバウトページ', () => {
     const passwordInput = page.getByLabel(/パスワード/i);
     await passwordInput.fill(TEST_PASSWORD);
 
-    const loginButton = page.getByRole('button', { name: /ログイン/i });
+    const loginButton = page.getByRole('button', { name: 'ログイン', exact: true });
     await loginButton.click();
 
     // ログイン後、トップページに遷移することを確認

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -43,7 +43,7 @@ test.describe('ログイン機能', () => {
     const passwordInput = page.getByLabel(/パスワード/i);
     await passwordInput.fill(TEST_PASSWORD);
 
-    const loginButton = page.getByRole('button', { name: /ログイン/i });
+    const loginButton = page.getByRole('button', { name: 'ログイン', exact: true });
     await loginButton.click();
 
     await page.waitForURL(/.*top/, { timeout: 10000 });
@@ -64,7 +64,7 @@ test.describe('ログイン機能', () => {
     const passwordInput = page.getByLabel(/パスワード/i);
     await passwordInput.fill(TEST_PASSWORD);
 
-    const loginButton = page.getByRole('button', { name: /ログイン/i });
+    const loginButton = page.getByRole('button', { name: 'ログイン', exact: true });
     await loginButton.click();
 
     await page.waitForURL(/.*top/, { timeout: 10000 });
@@ -93,7 +93,7 @@ test.describe('ログイン機能', () => {
     const passwordInput = page.getByLabel(/パスワード/i);
     await passwordInput.fill(TEST_PASSWORD);
 
-    const loginButton = page.getByRole('button', { name: /ログイン/i });
+    const loginButton = page.getByRole('button', { name: 'ログイン', exact: true });
     await loginButton.click();
 
     await page.waitForURL(/.*top/, { timeout: 10000 });
@@ -125,7 +125,7 @@ test.describe('ログイン機能', () => {
     await passwordInput.fill('wrong-password-123');
 
     // ログインボタンをクリック
-    const loginButton = page.getByRole('button', { name: /ログイン/i });
+    const loginButton = page.getByRole('button', { name: 'ログイン', exact: true });
     await loginButton.click();
 
     // エラーメッセージが表示されることを確認
@@ -146,7 +146,7 @@ test.describe('ログイン機能', () => {
     await passwordInput.fill(TEST_PASSWORD);
 
     // ログインボタンをクリック
-    const loginButton = page.getByRole('button', { name: /ログイン/i });
+    const loginButton = page.getByRole('button', { name: 'ログイン', exact: true });
     await loginButton.click();
 
     // エラーメッセージが表示されることを確認
@@ -163,7 +163,7 @@ test.describe('ログイン機能', () => {
     await passwordInput.fill(TEST_PASSWORD);
 
     // ログインボタンをクリック
-    const loginButton = page.getByRole('button', { name: /ログイン/i });
+    const loginButton = page.getByRole('button', { name: 'ログイン', exact: true });
     await loginButton.click();
 
     // エラーメッセージが表示されることを確認

--- a/frontend/e2e/top-navigation.spec.ts
+++ b/frontend/e2e/top-navigation.spec.ts
@@ -27,7 +27,7 @@ test.describe('トップページからの主要ナビゲーション', () => {
 
     await page.getByLabel(/メールアドレス/i).fill(TEST_EMAIL);
     await page.getByLabel(/パスワード/i).fill(TEST_PASSWORD);
-    await page.getByRole('button', { name: /ログイン/i }).click();
+    await page.getByRole('button', { name: 'ログイン', exact: true }).click();
 
     // トップページへの遷移を待機
     await page.waitForURL(/.*top/, { timeout: 10000 });

--- a/frontend/src/app/(auth)/_components/GoogleLoginButton.test.tsx
+++ b/frontend/src/app/(auth)/_components/GoogleLoginButton.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useGoogleLoginButton } from '@/app/(auth)/_hooks/useGoogleLoginButton';
+import GoogleLoginButton from './GoogleLoginButton';
+
+vi.mock('@/app/(auth)/_hooks/useGoogleLoginButton');
+
+describe('GoogleLoginButton', () => {
+  const mockHandleGoogleLogin = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('isLoading=falseの場合、「Googleでログイン」と表示されボタンが有効', () => {
+    vi.mocked(useGoogleLoginButton).mockReturnValue({
+      isLoading: false,
+      handleGoogleLogin: mockHandleGoogleLogin,
+    });
+
+    render(<GoogleLoginButton />);
+
+    const button = screen.getByRole('button', { name: /Googleでログイン/ });
+    expect(button).toBeInTheDocument();
+    expect(button).not.toBeDisabled();
+  });
+
+  it('isLoading=trueの場合、「ログイン中...」と表示されボタンが無効', () => {
+    vi.mocked(useGoogleLoginButton).mockReturnValue({
+      isLoading: true,
+      handleGoogleLogin: mockHandleGoogleLogin,
+    });
+
+    render(<GoogleLoginButton />);
+
+    const button = screen.getByRole('button', { name: /ログイン中.../ });
+    expect(button).toBeInTheDocument();
+    expect(button).toBeDisabled();
+  });
+
+  it('ボタンクリック時にhandleGoogleLoginが呼ばれる', async () => {
+    vi.mocked(useGoogleLoginButton).mockReturnValue({
+      isLoading: false,
+      handleGoogleLogin: mockHandleGoogleLogin,
+    });
+
+    render(<GoogleLoginButton />);
+
+    const button = screen.getByRole('button', { name: /Googleでログイン/ });
+    await userEvent.click(button);
+
+    expect(mockHandleGoogleLogin).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/app/(auth)/_components/GoogleLoginButton.tsx
+++ b/frontend/src/app/(auth)/_components/GoogleLoginButton.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useGoogleLoginButton } from '@/app/(auth)/_hooks/useGoogleLoginButton';
+
+export default function GoogleLoginButton() {
+  const { isLoading, handleGoogleLogin } = useGoogleLoginButton();
+
+  return (
+    <button
+      type="button"
+      onClick={handleGoogleLogin}
+      disabled={isLoading}
+      className="w-full py-3 px-4 bg-white hover:bg-gray-50 text-gray-700 font-medium rounded-lg border border-gray-300 shadow-sm transition-all hover:-translate-y-0.5 cursor-pointer disabled:bg-gray-100 disabled:text-gray-400 disabled:cursor-not-allowed disabled:translate-y-0 flex items-center justify-center gap-3"
+    >
+      <svg className="w-5 h-5" viewBox="0 0 24 24">
+        <path
+          fill="#4285F4"
+          d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+        />
+        <path
+          fill="#34A853"
+          d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        />
+        <path
+          fill="#FBBC05"
+          d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+        />
+        <path
+          fill="#EA4335"
+          d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        />
+      </svg>
+      {isLoading ? 'ログイン中...' : 'Googleでログイン'}
+    </button>
+  );
+}

--- a/frontend/src/app/(auth)/_components/forms/LoginForm.test.tsx
+++ b/frontend/src/app/(auth)/_components/forms/LoginForm.test.tsx
@@ -7,6 +7,10 @@ vi.mock('@/app/(auth)/_hooks/useLoginForm', () => ({
   useLoginForm: vi.fn(),
 }));
 
+vi.mock('@/app/(auth)/_components/GoogleLoginButton', () => ({
+  default: () => <button type="button">Googleでログイン</button>,
+}));
+
 describe('LoginForm', () => {
   // ヘルパー関数: useLoginForm のモックを設定
   const mockUseLoginForm = (overrides = {}) => {
@@ -58,6 +62,14 @@ describe('LoginForm', () => {
       const button = screen.getByRole('button', { name: 'ログイン' });
       expect(button).toHaveAttribute('type', 'submit');
       expect(button).not.toBeDisabled();
+    });
+
+    it('Googleログインボタンが存在する', () => {
+      mockUseLoginForm();
+
+      render(<LoginForm />);
+
+      expect(screen.getByRole('button', { name: 'Googleでログイン' })).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/app/(auth)/_components/forms/LoginForm.tsx
+++ b/frontend/src/app/(auth)/_components/forms/LoginForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import AuthInput from '@/app/(auth)/_components/forms/AuthInput';
+import GoogleLoginButton from '@/app/(auth)/_components/GoogleLoginButton';
 import { useLoginForm } from '@/app/(auth)/_hooks/useLoginForm';
 import { LoginFormData } from '@/schemas/auth';
 
@@ -8,33 +9,46 @@ export default function LoginForm() {
   const { register, handleSubmit, errors, isSubmitting, onSubmit } = useLoginForm();
 
   return (
-    <form className="space-y-5" onSubmit={handleSubmit(onSubmit)}>
-      <div className="space-y-4">
-        <AuthInput<LoginFormData>
-          name="email"
-          label="メールアドレス"
-          type="email"
-          placeholder="example@email.com"
-          register={register}
-          error={errors.email?.message}
-        />
-        <AuthInput<LoginFormData>
-          name="password"
-          label="パスワード"
-          type="password"
-          placeholder="パスワードを入力"
-          register={register}
-          error={errors.password?.message}
-        />
+    <div className="space-y-5">
+      <GoogleLoginButton />
+
+      <div className="relative">
+        <div className="absolute inset-0 flex items-center">
+          <div className="w-full border-t border-gray-300" />
+        </div>
+        <div className="relative flex justify-center text-sm">
+          <span className="px-2 bg-white text-gray-500">または</span>
+        </div>
       </div>
 
-      <button
-        type="submit"
-        disabled={isSubmitting}
-        className="w-full py-3 px-4 bg-sky-600 hover:bg-sky-700 text-white font-bold rounded-lg shadow-md shadow-sky-200 transition-all hover:-translate-y-0.5 disabled:bg-slate-300 disabled:text-slate-500 disabled:cursor-not-allowed disabled:shadow-none disabled:translate-y-0"
-      >
-        {isSubmitting ? 'ログイン中...' : 'ログイン'}
-      </button>
-    </form>
+      <form className="space-y-5" onSubmit={handleSubmit(onSubmit)}>
+        <div className="space-y-4">
+          <AuthInput<LoginFormData>
+            name="email"
+            label="メールアドレス"
+            type="email"
+            placeholder="example@email.com"
+            register={register}
+            error={errors.email?.message}
+          />
+          <AuthInput<LoginFormData>
+            name="password"
+            label="パスワード"
+            type="password"
+            placeholder="パスワードを入力"
+            register={register}
+            error={errors.password?.message}
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="w-full py-3 px-4 bg-sky-600 hover:bg-sky-700 text-white font-bold rounded-lg shadow-md shadow-sky-200 transition-all hover:-translate-y-0.5 cursor-pointer disabled:bg-slate-300 disabled:text-slate-500 disabled:cursor-not-allowed disabled:shadow-none disabled:translate-y-0"
+        >
+          {isSubmitting ? 'ログイン中...' : 'ログイン'}
+        </button>
+      </form>
+    </div>
   );
 }

--- a/frontend/src/app/(auth)/_components/forms/RegisterForm.test.tsx
+++ b/frontend/src/app/(auth)/_components/forms/RegisterForm.test.tsx
@@ -7,6 +7,10 @@ vi.mock('@/app/(auth)/_hooks/useRegisterForm', () => ({
   useRegisterForm: vi.fn(),
 }));
 
+vi.mock('@/app/(auth)/_components/GoogleLoginButton', () => ({
+  default: () => <button type="button">Googleでログイン</button>,
+}));
+
 describe('RegisterForm', () => {
   // ヘルパー関数: useRegisterForm のモックを設定
   const mockUseRegisterForm = (overrides = {}) => {
@@ -78,6 +82,14 @@ describe('RegisterForm', () => {
       const button = screen.getByRole('button', { name: '登録' });
       expect(button).toHaveAttribute('type', 'submit');
       expect(button).not.toBeDisabled();
+    });
+
+    it('Googleログインボタンが存在する', () => {
+      mockUseRegisterForm();
+
+      render(<RegisterForm />);
+
+      expect(screen.getByRole('button', { name: 'Googleでログイン' })).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/app/(auth)/_components/forms/RegisterForm.tsx
+++ b/frontend/src/app/(auth)/_components/forms/RegisterForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import AuthInput from '@/app/(auth)/_components/forms/AuthInput';
+import GoogleLoginButton from '@/app/(auth)/_components/GoogleLoginButton';
 import { useRegisterForm } from '@/app/(auth)/_hooks/useRegisterForm';
 import { RegisterFormData } from '@/schemas/auth';
 
@@ -8,49 +9,62 @@ export default function RegisterForm() {
   const { register, handleSubmit, errors, isSubmitting, onSubmit } = useRegisterForm();
 
   return (
-    <form className="space-y-5" onSubmit={handleSubmit(onSubmit)}>
-      <div className="space-y-4">
-        <AuthInput<RegisterFormData>
-          name="name"
-          label="ユーザー名"
-          type="text"
-          placeholder="ユーザー名を入力"
-          register={register}
-          error={errors.name?.message}
-        />
-        <AuthInput<RegisterFormData>
-          name="email"
-          label="メールアドレス"
-          type="email"
-          placeholder="example@email.com"
-          register={register}
-          error={errors.email?.message}
-        />
-        <AuthInput<RegisterFormData>
-          name="password"
-          label="パスワード"
-          type="password"
-          placeholder="8文字以上で入力"
-          register={register}
-          error={errors.password?.message}
-        />
-        <AuthInput<RegisterFormData>
-          name="passwordConfirmation"
-          label="パスワード確認"
-          type="password"
-          placeholder="パスワードを再入力"
-          register={register}
-          error={errors.passwordConfirmation?.message}
-        />
+    <div className="space-y-5">
+      <GoogleLoginButton />
+
+      <div className="relative">
+        <div className="absolute inset-0 flex items-center">
+          <div className="w-full border-t border-gray-300" />
+        </div>
+        <div className="relative flex justify-center text-sm">
+          <span className="px-2 bg-white text-gray-500">または</span>
+        </div>
       </div>
 
-      <button
-        type="submit"
-        disabled={isSubmitting}
-        className="w-full py-3 px-4 bg-sky-600 hover:bg-sky-700 text-white font-bold rounded-lg shadow-md shadow-sky-200 transition-all hover:-translate-y-0.5 disabled:bg-slate-300 disabled:text-slate-500 disabled:cursor-not-allowed disabled:shadow-none disabled:translate-y-0"
-      >
-        {isSubmitting ? '登録中...' : '登録'}
-      </button>
-    </form>
+      <form className="space-y-5" onSubmit={handleSubmit(onSubmit)}>
+        <div className="space-y-4">
+          <AuthInput<RegisterFormData>
+            name="name"
+            label="ユーザー名"
+            type="text"
+            placeholder="ユーザー名を入力"
+            register={register}
+            error={errors.name?.message}
+          />
+          <AuthInput<RegisterFormData>
+            name="email"
+            label="メールアドレス"
+            type="email"
+            placeholder="example@email.com"
+            register={register}
+            error={errors.email?.message}
+          />
+          <AuthInput<RegisterFormData>
+            name="password"
+            label="パスワード"
+            type="password"
+            placeholder="8文字以上で入力"
+            register={register}
+            error={errors.password?.message}
+          />
+          <AuthInput<RegisterFormData>
+            name="passwordConfirmation"
+            label="パスワード確認"
+            type="password"
+            placeholder="パスワードを再入力"
+            register={register}
+            error={errors.passwordConfirmation?.message}
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="w-full py-3 px-4 bg-sky-600 hover:bg-sky-700 text-white font-bold rounded-lg shadow-md shadow-sky-200 transition-all hover:-translate-y-0.5 cursor-pointer disabled:bg-slate-300 disabled:text-slate-500 disabled:cursor-not-allowed disabled:shadow-none disabled:translate-y-0"
+        >
+          {isSubmitting ? '登録中...' : '登録'}
+        </button>
+      </form>
+    </div>
   );
 }

--- a/frontend/src/app/(auth)/_hooks/useGoogleLoginButton.test.ts
+++ b/frontend/src/app/(auth)/_hooks/useGoogleLoginButton.test.ts
@@ -15,53 +15,51 @@ describe('useGoogleLoginButton', () => {
   describe('初期状態', () => {
     it('isLoading が false', () => {
       const { result } = renderHook(() => useGoogleLoginButton());
-  
+
       expect(result.current.isLoading).toBe(false);
     });
-  })
+  });
 
   describe('handleGoogleLogin', () => {
     it('実行時に signInWithGoogle が呼ばれる', async () => {
       vi.mocked(signInWithGoogle).mockResolvedValue(null);
-  
+
       const { result } = renderHook(() => useGoogleLoginButton());
-  
+
       await act(async () => {
         await result.current.handleGoogleLogin();
       });
-  
+
       expect(signInWithGoogle).toHaveBeenCalledTimes(1);
     });
-  
+
     it('エラー時にトーストが表示され isLoading が false になる', async () => {
       vi.mocked(signInWithGoogle).mockResolvedValue('OAuth error');
-  
+
       const { result } = renderHook(() => useGoogleLoginButton());
-  
+
       await act(async () => {
         await result.current.handleGoogleLogin();
       });
-  
+
       await waitFor(() => {
         expect(toast.error).toHaveBeenCalledWith('Googleログインに失敗しました');
         expect(result.current.isLoading).toBe(false);
       });
     });
-  
+
     it('成功時にトーストが表示される', async () => {
       vi.mocked(signInWithGoogle).mockResolvedValue(null);
-  
+
       const { result } = renderHook(() => useGoogleLoginButton());
-  
+
       await act(async () => {
         await result.current.handleGoogleLogin();
       });
-  
+
       await waitFor(() => {
         expect(toast.success).toHaveBeenCalledWith('ログインしました');
       });
     });
-
-  })
-
+  });
 });

--- a/frontend/src/app/(auth)/_hooks/useGoogleLoginButton.test.ts
+++ b/frontend/src/app/(auth)/_hooks/useGoogleLoginButton.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import toast from 'react-hot-toast';
+import { signInWithGoogle } from '@/app/(auth)/_lib/oauth';
+import { useGoogleLoginButton } from './useGoogleLoginButton';
+
+vi.mock('@/app/(auth)/_lib/oauth');
+vi.mock('react-hot-toast');
+
+describe('useGoogleLoginButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('初期状態', () => {
+    it('isLoading が false', () => {
+      const { result } = renderHook(() => useGoogleLoginButton());
+  
+      expect(result.current.isLoading).toBe(false);
+    });
+  })
+
+  describe('handleGoogleLogin', () => {
+    it('実行時に signInWithGoogle が呼ばれる', async () => {
+      vi.mocked(signInWithGoogle).mockResolvedValue(null);
+  
+      const { result } = renderHook(() => useGoogleLoginButton());
+  
+      await act(async () => {
+        await result.current.handleGoogleLogin();
+      });
+  
+      expect(signInWithGoogle).toHaveBeenCalledTimes(1);
+    });
+  
+    it('エラー時にトーストが表示され isLoading が false になる', async () => {
+      vi.mocked(signInWithGoogle).mockResolvedValue('OAuth error');
+  
+      const { result } = renderHook(() => useGoogleLoginButton());
+  
+      await act(async () => {
+        await result.current.handleGoogleLogin();
+      });
+  
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith('Googleログインに失敗しました');
+        expect(result.current.isLoading).toBe(false);
+      });
+    });
+  
+    it('成功時にトーストが表示される', async () => {
+      vi.mocked(signInWithGoogle).mockResolvedValue(null);
+  
+      const { result } = renderHook(() => useGoogleLoginButton());
+  
+      await act(async () => {
+        await result.current.handleGoogleLogin();
+      });
+  
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith('ログインしました');
+      });
+    });
+
+  })
+
+});

--- a/frontend/src/app/(auth)/_hooks/useGoogleLoginButton.ts
+++ b/frontend/src/app/(auth)/_hooks/useGoogleLoginButton.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+import { signInWithGoogle } from '@/app/(auth)/_lib/oauth';
+import toast from 'react-hot-toast';
+
+export function useGoogleLoginButton() {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleGoogleLogin = async () => {
+    setIsLoading(true);
+
+    const error = await signInWithGoogle();
+
+    if (error) {
+      toast.error('Googleログインに失敗しました');
+      setIsLoading(false);
+    } else {
+      // 成功時はリダイレクトされるため、setIsLoading(false)は不要
+      toast.success('ログインしました');
+    }
+  };
+
+  return {
+    isLoading,
+    handleGoogleLogin,
+  };
+}

--- a/frontend/src/app/(auth)/_hooks/useRegisterForm.test.ts
+++ b/frontend/src/app/(auth)/_hooks/useRegisterForm.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
-import { signUpAction } from '../_lib';
+import { signUpAction, loginClientSide } from '../_lib';
 import { RegisterFormData } from '@/schemas/auth';
 import { useRegisterForm } from './useRegisterForm';
 import toast from 'react-hot-toast';
@@ -16,6 +16,7 @@ vi.mock('next/navigation', () => ({
 // 認証関連の関数をモック
 vi.mock('@/app/(auth)/_lib', () => ({
   signUpAction: vi.fn(),
+  loginClientSide: vi.fn(),
 }));
 
 // react-hot-toast をモック
@@ -50,6 +51,7 @@ describe('useRegisterForm', () => {
   describe('onSubmit: 正常系', () => {
     beforeEach(() => {
       vi.mocked(signUpAction).mockResolvedValue(null);
+      vi.mocked(loginClientSide).mockResolvedValue(null);
     });
 
     it('signUpAction が呼ばれる', async () => {
@@ -74,7 +76,7 @@ describe('useRegisterForm', () => {
     });
   });
 
-  describe('onSubmit: 異常系', () => {
+  describe('onSubmit: 異常系（signUpActionエラー）', () => {
     beforeEach(() => {
       vi.mocked(signUpAction).mockResolvedValue('エラーです');
     });
@@ -85,6 +87,30 @@ describe('useRegisterForm', () => {
       await act(() => result.current.onSubmit(mockRegisterFormData));
 
       expect(toast.error).toHaveBeenCalledWith('エラーです');
+    });
+
+    it('トップページへ遷移されない', async () => {
+      const { result } = renderHook(() => useRegisterForm());
+
+      await act(() => result.current.onSubmit(mockRegisterFormData));
+
+      expect(toast.success).not.toHaveBeenCalledWith('ユーザー登録が完了しました');
+      expect(mockPush).not.toHaveBeenCalledWith('/top');
+    });
+  });
+
+  describe('onSubmit: 異常系（loginClientSideエラー）', () => {
+    beforeEach(() => {
+      vi.mocked(signUpAction).mockResolvedValue(null);
+      vi.mocked(loginClientSide).mockResolvedValue('ログインエラーです');
+    });
+
+    it('loginClientSide のエラーメッセージがトーストで表示される', async () => {
+      const { result } = renderHook(() => useRegisterForm());
+
+      await act(() => result.current.onSubmit(mockRegisterFormData));
+
+      expect(toast.error).toHaveBeenCalledWith('ログインエラーです');
     });
 
     it('トップページへ遷移されない', async () => {

--- a/frontend/src/app/(auth)/_hooks/useRegisterForm.ts
+++ b/frontend/src/app/(auth)/_hooks/useRegisterForm.ts
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import toast from 'react-hot-toast';
 import { registerSchema, type RegisterFormData } from '@/schemas/auth';
-import { signUpAction } from '@/app/(auth)/_lib';
+import { signUpAction, loginClientSide } from '@/app/(auth)/_lib';
 
 export function useRegisterForm() {
   const router = useRouter();
@@ -21,6 +21,14 @@ export function useRegisterForm() {
 
     if (error) {
       toast.error(error);
+      return;
+    }
+
+    // クライアント側でログインしてonAuthStateChangeを発火させる
+    const clientError = await loginClientSide({ email: data.email, password: data.password });
+
+    if (clientError) {
+      toast.error(clientError);
       return;
     }
 

--- a/frontend/src/app/(auth)/_lib/index.ts
+++ b/frontend/src/app/(auth)/_lib/index.ts
@@ -1,2 +1,3 @@
 export * from './session';
 export * from './sessionClient';
+export * from './oauth';

--- a/frontend/src/app/(auth)/_lib/oauth.test.ts
+++ b/frontend/src/app/(auth)/_lib/oauth.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createBrowserSupabaseClient } from '@/supabase/clients/browser';
+import { signInWithGoogle } from './oauth';
+
+vi.mock('@/supabase/clients/browser');
+
+describe('signInWithGoogle', () => {
+  const mockSignInWithOAuth = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(createBrowserSupabaseClient).mockReturnValue({
+      auth: {
+        signInWithOAuth: mockSignInWithOAuth,
+      },
+    } as unknown as ReturnType<typeof createBrowserSupabaseClient>);
+  });
+
+  it('Googleプロバイダーと正しいリダイレクトURLで呼ばれる', async () => {
+    mockSignInWithOAuth.mockResolvedValue({ error: null });
+
+    await signInWithGoogle();
+
+    expect(mockSignInWithOAuth).toHaveBeenCalledTimes(1);
+    expect(mockSignInWithOAuth).toHaveBeenCalledWith({
+      provider: 'google',
+      options: {
+        redirectTo: expect.stringContaining('/auth/callback?next=/top'),
+      },
+    });
+  });
+
+  it('成功時はnullを返す', async () => {
+    mockSignInWithOAuth.mockResolvedValue({ error: null });
+
+    const result = await signInWithGoogle();
+
+    expect(result).toBeNull();
+  });
+
+  it('エラー時はエラーメッセージを返す', async () => {
+    mockSignInWithOAuth.mockResolvedValue({
+      error: { message: 'OAuth error' },
+    });
+
+    const result = await signInWithGoogle();
+
+    expect(result).toBe('OAuth error');
+  });
+});

--- a/frontend/src/app/(auth)/_lib/oauth.ts
+++ b/frontend/src/app/(auth)/_lib/oauth.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { createBrowserSupabaseClient } from '@/supabase/clients/browser';
+
+/**
+ * GoogleアカウントでOAuthログインを開始
+ *
+ * この関数を呼び出すと、Googleの認証画面にリダイレクトされます。
+ * 認証成功後、/auth/callbackにリダイレクトされ、セッションが確立されます。
+ *
+ * @returns エラーメッセージ、またはnull（リダイレクト成功時）
+ */
+export async function signInWithGoogle(): Promise<string | null> {
+  const supabase = createBrowserSupabaseClient();
+
+  const { error } = await supabase.auth.signInWithOAuth({
+    provider: 'google',
+    options: {
+      redirectTo: `${window.location.origin}/auth/callback?next=/top`,
+    },
+  });
+
+  if (error) {
+    return error.message;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## 概要
Supabase AuthのGoogle OAuthを使用したログイン機能を実装

## 詳細
### 実装内容
- Google OAuthログイン機能の追加
  - `signInWithGoogle`関数（OAuth認証開始）
  - `useGoogleLoginButton`カスタムフック
  - `GoogleLoginButton`コンポーネント
- ログイン・登録フォームへのGoogleログインボタン追加
  - 「または」の区切り線でUIを改善
  - ボタンホバー時のカーソル表示を改善

### バグ修正
- 新規登録後にヘッダーが更新されない問題を修正
  - クライアント側でもログイン処理を実行し`onAuthStateChange`を発火
- E2Eテストのログインボタンセレクタを修正
  - strict mode違反を解消（exact matchに変更）

### テスト
- 各機能のユニットテストを追加
- E2Eテスト全17件がパス

## 設定
### Google Cloud Console
- OAuthクライアントID作成済み
- リダイレクトURI設定済み

### Supabase Dashboard
- Google Provider有効化済み

### 本番環境
- Vercel/Render側の追加設定は不要（既存環境変数で動作）

## 関連Issue
Closes #159