### PR TITLE
refactor: fetch/mutation共通化、loading.tsx追加、e2eテスト修正

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -115,3 +115,7 @@ symbol_info_budget:
 # Note: the backend is fixed at startup. If a project with a different backend
 # is activated post-init, an error will be returned.
 language_backend:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []

--- a/frontend/e2e/books.spec.ts
+++ b/frontend/e2e/books.spec.ts
@@ -74,6 +74,11 @@ test.describe('書籍詳細ページ', () => {
   });
 
   test('書籍一覧から詳細ページへ遷移できる', async ({ page }) => {
+    // データ読み込み完了を待機（「詳細」リンクまたはEmptyStateが表示されるまで）
+    await expect(
+      page.getByRole('link', { name: '詳細' }).first().or(page.getByText(/本が登録されていません/i)),
+    ).toBeVisible();
+
     // 書籍カードの「詳細」リンクをクリック（最初の書籍）
     const bookDetailLink = page.getByRole('link', { name: '詳細' }).first();
 
@@ -95,6 +100,11 @@ test.describe('書籍詳細ページ', () => {
   });
 
   test('書籍詳細ページで編集モーダルが開ける', async ({ page }) => {
+    // データ読み込み完了を待機
+    await expect(
+      page.getByRole('link', { name: '詳細' }).first().or(page.getByText(/本が登録されていません/i)),
+    ).toBeVisible();
+
     // 書籍カードの「詳細」リンクをクリック（最初の書籍）
     const bookDetailLink = page.getByRole('link', { name: '詳細' }).first();
 
@@ -117,6 +127,11 @@ test.describe('書籍詳細ページ', () => {
   });
 
   test('書籍詳細ページでタブ切り替えができる', async ({ page }) => {
+    // データ読み込み完了を待機
+    await expect(
+      page.getByRole('link', { name: '詳細' }).first().or(page.getByText(/本が登録されていません/i)),
+    ).toBeVisible();
+
     // 書籍カードの「詳細」リンクをクリック（最初の書籍）
     const bookDetailLink = page.getByRole('link', { name: '詳細' }).first();
 
@@ -147,6 +162,11 @@ test.describe('書籍の編集フロー', () => {
   test('書籍のステータスを変更できる', async ({ page }) => {
     // 書籍一覧ページへ遷移
     await page.goto('/books');
+
+    // データ読み込み完了を待機
+    await expect(
+      page.getByRole('link', { name: '詳細' }).first().or(page.getByText(/本が登録されていません/i)),
+    ).toBeVisible();
 
     // 書籍カードの「詳細」リンクをクリック（最初の書籍）
     const bookDetailLink = page.getByRole('link', { name: '詳細' }).first();

--- a/frontend/e2e/books.spec.ts
+++ b/frontend/e2e/books.spec.ts
@@ -76,7 +76,10 @@ test.describe('書籍詳細ページ', () => {
   test('書籍一覧から詳細ページへ遷移できる', async ({ page }) => {
     // データ読み込み完了を待機（「詳細」リンクまたはEmptyStateが表示されるまで）
     await expect(
-      page.getByRole('link', { name: '詳細' }).first().or(page.getByText(/本が登録されていません/i)),
+      page
+        .getByRole('link', { name: '詳細' })
+        .first()
+        .or(page.getByText(/本が登録されていません/i)),
     ).toBeVisible();
 
     // 書籍カードの「詳細」リンクをクリック（最初の書籍）
@@ -102,7 +105,10 @@ test.describe('書籍詳細ページ', () => {
   test('書籍詳細ページで編集モーダルが開ける', async ({ page }) => {
     // データ読み込み完了を待機
     await expect(
-      page.getByRole('link', { name: '詳細' }).first().or(page.getByText(/本が登録されていません/i)),
+      page
+        .getByRole('link', { name: '詳細' })
+        .first()
+        .or(page.getByText(/本が登録されていません/i)),
     ).toBeVisible();
 
     // 書籍カードの「詳細」リンクをクリック（最初の書籍）
@@ -129,7 +135,10 @@ test.describe('書籍詳細ページ', () => {
   test('書籍詳細ページでタブ切り替えができる', async ({ page }) => {
     // データ読み込み完了を待機
     await expect(
-      page.getByRole('link', { name: '詳細' }).first().or(page.getByText(/本が登録されていません/i)),
+      page
+        .getByRole('link', { name: '詳細' })
+        .first()
+        .or(page.getByText(/本が登録されていません/i)),
     ).toBeVisible();
 
     // 書籍カードの「詳細」リンクをクリック（最初の書籍）
@@ -165,7 +174,10 @@ test.describe('書籍の編集フロー', () => {
 
     // データ読み込み完了を待機
     await expect(
-      page.getByRole('link', { name: '詳細' }).first().or(page.getByText(/本が登録されていません/i)),
+      page
+        .getByRole('link', { name: '詳細' })
+        .first()
+        .or(page.getByText(/本が登録されていません/i)),
     ).toBeVisible();
 
     // 書籍カードの「詳細」リンクをクリック（最初の書籍）

--- a/frontend/e2e/cards.spec.ts
+++ b/frontend/e2e/cards.spec.ts
@@ -15,7 +15,10 @@ test.describe('カード一覧ページ', () => {
   test('書籍グループの展開・折りたたみができる', async ({ page }) => {
     // データ読み込み完了を待機
     await expect(
-      page.getByTestId('expand').first().or(page.getByText(/カードが登録されていません/i)),
+      page
+        .getByTestId('expand')
+        .first()
+        .or(page.getByText(/カードが登録されていません/i)),
     ).toBeVisible();
 
     const cardExpandButton = page.getByTestId('expand').first();
@@ -43,7 +46,10 @@ test.describe('カード一覧ページ', () => {
   test('「カードを作成」ボタンでモーダルが開ける', async ({ page }) => {
     // データ読み込み完了を待機
     await expect(
-      page.getByRole('button', { name: 'カードを作成' }).first().or(page.getByText(/カードが登録されていません/i)),
+      page
+        .getByRole('button', { name: 'カードを作成' })
+        .first()
+        .or(page.getByText(/カードが登録されていません/i)),
     ).toBeVisible();
 
     const createCardButton = page.getByRole('button', { name: 'カードを作成' }).first();
@@ -69,7 +75,10 @@ test.describe('カード詳細ページ', () => {
   test('カード一覧から詳細ページへ遷移できる', async ({ page }) => {
     // データ読み込み完了を待機
     await expect(
-      page.getByTestId('expand').first().or(page.getByText(/カードが登録されていません/i)),
+      page
+        .getByTestId('expand')
+        .first()
+        .or(page.getByText(/カードが登録されていません/i)),
     ).toBeVisible();
 
     const cardExpandButton = page.getByTestId('expand').first();
@@ -100,7 +109,10 @@ test.describe('カード詳細ページ', () => {
   test('カード詳細ページで編集モーダルが開ける', async ({ page }) => {
     // データ読み込み完了を待機
     await expect(
-      page.getByTestId('expand').first().or(page.getByText(/カードが登録されていません/i)),
+      page
+        .getByTestId('expand')
+        .first()
+        .or(page.getByText(/カードが登録されていません/i)),
     ).toBeVisible();
 
     const cardExpandButton = page.getByTestId('expand').first();
@@ -143,7 +155,10 @@ test.describe('カードの編集フロー', () => {
   test('カードの詳細を変更できる', async ({ page }) => {
     // データ読み込み完了を待機
     await expect(
-      page.getByTestId('expand').first().or(page.getByText(/カードが登録されていません/i)),
+      page
+        .getByTestId('expand')
+        .first()
+        .or(page.getByText(/カードが登録されていません/i)),
     ).toBeVisible();
 
     const cardExpandButton = page.getByTestId('expand').first();

--- a/frontend/e2e/cards.spec.ts
+++ b/frontend/e2e/cards.spec.ts
@@ -13,6 +13,11 @@ test.describe('カード一覧ページ', () => {
   });
 
   test('書籍グループの展開・折りたたみができる', async ({ page }) => {
+    // データ読み込み完了を待機
+    await expect(
+      page.getByTestId('expand').first().or(page.getByText(/カードが登録されていません/i)),
+    ).toBeVisible();
+
     const cardExpandButton = page.getByTestId('expand').first();
     const groupExists = (await cardExpandButton.count()) > 0;
 
@@ -36,7 +41,12 @@ test.describe('カード一覧ページ', () => {
   });
 
   test('「カードを作成」ボタンでモーダルが開ける', async ({ page }) => {
-    const createCardButton = page.getByRole('button', { name: /カードを作成/i }).first();
+    // データ読み込み完了を待機
+    await expect(
+      page.getByRole('button', { name: 'カードを作成' }).first().or(page.getByText(/カードが登録されていません/i)),
+    ).toBeVisible();
+
+    const createCardButton = page.getByRole('button', { name: 'カードを作成' }).first();
     const buttonExists = (await createCardButton.count()) > 0;
 
     if (buttonExists) {
@@ -57,6 +67,11 @@ test.describe('カード詳細ページ', () => {
   });
 
   test('カード一覧から詳細ページへ遷移できる', async ({ page }) => {
+    // データ読み込み完了を待機
+    await expect(
+      page.getByTestId('expand').first().or(page.getByText(/カードが登録されていません/i)),
+    ).toBeVisible();
+
     const cardExpandButton = page.getByTestId('expand').first();
     const groupExists = (await cardExpandButton.count()) > 0;
 
@@ -83,6 +98,11 @@ test.describe('カード詳細ページ', () => {
   });
 
   test('カード詳細ページで編集モーダルが開ける', async ({ page }) => {
+    // データ読み込み完了を待機
+    await expect(
+      page.getByTestId('expand').first().or(page.getByText(/カードが登録されていません/i)),
+    ).toBeVisible();
+
     const cardExpandButton = page.getByTestId('expand').first();
     const groupExists = (await cardExpandButton.count()) > 0;
 
@@ -121,6 +141,11 @@ test.describe('カードの編集フロー', () => {
   });
 
   test('カードの詳細を変更できる', async ({ page }) => {
+    // データ読み込み完了を待機
+    await expect(
+      page.getByTestId('expand').first().or(page.getByText(/カードが登録されていません/i)),
+    ).toBeVisible();
+
     const cardExpandButton = page.getByTestId('expand').first();
     const groupExists = (await cardExpandButton.count()) > 0;
 

--- a/frontend/e2e/lists.spec.ts
+++ b/frontend/e2e/lists.spec.ts
@@ -31,6 +31,11 @@ test.describe('リスト詳細ページ', () => {
   });
 
   test('リスト一覧から詳細ページへ遷移できる', async ({ page }) => {
+    // データ読み込み完了を待機（「詳細」リンクまたはEmptyStateが表示されるまで）
+    await expect(
+      page.getByRole('link', { name: '詳細' }).first().or(page.getByText(/リストが登録されていません/i)),
+    ).toBeVisible();
+
     // リストカードの「詳細」リンクをクリック（最初のリスト）
     const listDetailLink = page.getByRole('link', { name: '詳細' }).first();
 
@@ -52,6 +57,11 @@ test.describe('リスト詳細ページ', () => {
   });
 
   test('リスト詳細ページで編集モーダルが開ける', async ({ page }) => {
+    // データ読み込み完了を待機
+    await expect(
+      page.getByRole('link', { name: '詳細' }).first().or(page.getByText(/リストが登録されていません/i)),
+    ).toBeVisible();
+
     // リストカードの「詳細」リンクをクリック（最初のリスト）
     const listDetailLink = page.getByRole('link', { name: '詳細' }).first();
 
@@ -74,6 +84,11 @@ test.describe('リスト詳細ページ', () => {
   });
 
   test('リスト詳細ページで「本を追加」モーダルが開ける', async ({ page }) => {
+    // データ読み込み完了を待機
+    await expect(
+      page.getByRole('link', { name: '詳細' }).first().or(page.getByText(/リストが登録されていません/i)),
+    ).toBeVisible();
+
     // リストカードの「詳細」リンクをクリック（最初のリスト）
     const listDetailLink = page.getByRole('link', { name: '詳細' }).first();
 
@@ -102,6 +117,11 @@ test.describe('リストの編集フロー', () => {
   });
 
   test('リストの詳細を変更できる', async ({ page }) => {
+    // データ読み込み完了を待機
+    await expect(
+      page.getByRole('link', { name: '詳細' }).first().or(page.getByText(/リストが登録されていません/i)),
+    ).toBeVisible();
+
     // リストカードの「詳細」リンクをクリック（最初のリスト）
     const listDetailLink = page.getByRole('link', { name: '詳細' }).first();
 

--- a/frontend/e2e/lists.spec.ts
+++ b/frontend/e2e/lists.spec.ts
@@ -33,7 +33,10 @@ test.describe('リスト詳細ページ', () => {
   test('リスト一覧から詳細ページへ遷移できる', async ({ page }) => {
     // データ読み込み完了を待機（「詳細」リンクまたはEmptyStateが表示されるまで）
     await expect(
-      page.getByRole('link', { name: '詳細' }).first().or(page.getByText(/リストが登録されていません/i)),
+      page
+        .getByRole('link', { name: '詳細' })
+        .first()
+        .or(page.getByText(/リストが登録されていません/i)),
     ).toBeVisible();
 
     // リストカードの「詳細」リンクをクリック（最初のリスト）
@@ -59,7 +62,10 @@ test.describe('リスト詳細ページ', () => {
   test('リスト詳細ページで編集モーダルが開ける', async ({ page }) => {
     // データ読み込み完了を待機
     await expect(
-      page.getByRole('link', { name: '詳細' }).first().or(page.getByText(/リストが登録されていません/i)),
+      page
+        .getByRole('link', { name: '詳細' })
+        .first()
+        .or(page.getByText(/リストが登録されていません/i)),
     ).toBeVisible();
 
     // リストカードの「詳細」リンクをクリック（最初のリスト）
@@ -86,7 +92,10 @@ test.describe('リスト詳細ページ', () => {
   test('リスト詳細ページで「本を追加」モーダルが開ける', async ({ page }) => {
     // データ読み込み完了を待機
     await expect(
-      page.getByRole('link', { name: '詳細' }).first().or(page.getByText(/リストが登録されていません/i)),
+      page
+        .getByRole('link', { name: '詳細' })
+        .first()
+        .or(page.getByText(/リストが登録されていません/i)),
     ).toBeVisible();
 
     // リストカードの「詳細」リンクをクリック（最初のリスト）
@@ -119,7 +128,10 @@ test.describe('リストの編集フロー', () => {
   test('リストの詳細を変更できる', async ({ page }) => {
     // データ読み込み完了を待機
     await expect(
-      page.getByRole('link', { name: '詳細' }).first().or(page.getByText(/リストが登録されていません/i)),
+      page
+        .getByRole('link', { name: '詳細' })
+        .first()
+        .or(page.getByText(/リストが登録されていません/i)),
     ).toBeVisible();
 
     // リストカードの「詳細」リンクをクリック（最初のリスト）

--- a/frontend/src/app/(protected)/books/[id]/loading.tsx
+++ b/frontend/src/app/(protected)/books/[id]/loading.tsx
@@ -1,0 +1,68 @@
+export default function BookDetailLoading() {
+  return (
+    <div className="flex flex-col gap-8">
+      {/* パンくずリスト */}
+      <nav className="flex flex-wrap items-center gap-2 min-w-0">
+        <div className="h-4 w-12 animate-pulse rounded bg-slate-200" />
+        <span className="text-slate-400">/</span>
+        <div className="h-4 w-20 animate-pulse rounded bg-slate-200" />
+      </nav>
+
+      {/* メインカード */}
+      <div className="flex flex-col sm:flex-row gap-6 p-6 sm:p-8 bg-white rounded-xl border border-slate-200">
+        <div className="w-32 h-44 shrink-0 animate-pulse rounded-lg bg-slate-200" />
+        <div className="flex flex-col gap-4 min-w-0">
+          {/* タイトル・著者 */}
+          <div className="flex flex-col gap-1">
+            <div className="h-9 w-3/4 animate-pulse rounded bg-slate-200" />
+            <div className="h-5 w-1/2 animate-pulse rounded bg-slate-200" />
+          </div>
+
+          {/* バッジ */}
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-2">
+            <div className="h-6 w-20 animate-pulse rounded-full bg-slate-200" />
+            <div className="h-6 w-16 animate-pulse rounded-full bg-slate-200" />
+            <div className="h-6 w-24 animate-pulse rounded-full bg-slate-200" />
+          </div>
+
+          {/* 評価 */}
+          <div className="flex items-center gap-1">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="h-4 w-4 animate-pulse rounded bg-slate-200" />
+            ))}
+          </div>
+
+          {/* 説明 */}
+          <div className="flex flex-col gap-1">
+            <div className="h-4 w-full animate-pulse rounded bg-slate-200" />
+            <div className="h-4 w-5/6 animate-pulse rounded bg-slate-200" />
+          </div>
+
+          {/* メタデータ */}
+          <div className="flex flex-wrap gap-x-6 gap-y-2 pt-2 border-t border-slate-200">
+            <div className="h-4 w-32 animate-pulse rounded bg-slate-200" />
+            <div className="h-4 w-32 animate-pulse rounded bg-slate-200" />
+          </div>
+
+          {/* アクションボタン */}
+          <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3 pt-4">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="h-10 w-full sm:w-28 animate-pulse rounded-lg bg-slate-200" />
+            ))}
+            <div className="sm:ml-auto h-10 w-full sm:w-20 animate-pulse rounded-lg bg-slate-200" />
+          </div>
+        </div>
+      </div>
+
+      {/* タブ */}
+      <div className="flex flex-col">
+        <div className="border-b border-slate-200">
+          <nav className="-mb-px flex gap-6">
+            <div className="h-8 w-44 animate-pulse rounded bg-slate-200" />
+            <div className="h-8 w-32 animate-pulse rounded bg-slate-200" />
+          </nav>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(protected)/books/[id]/page.tsx
+++ b/frontend/src/app/(protected)/books/[id]/page.tsx
@@ -4,6 +4,7 @@ import { queryKeys } from '@/constants/queryKeys';
 import BookDetailClient from '@/app/(protected)/books/_components/clients/BookDetailClient';
 import { authenticatedRequest } from '@/supabase/dal';
 import { bookDetailSchema } from '@/app/(protected)/books/_types/';
+import { userSchema } from '@/schemas/user';
 
 type Props = {
   params: Promise<{ id: string }>;
@@ -14,13 +15,22 @@ export default async function BookPage({ params }: Props) {
 
   const queryClient = createServerQueryClient();
 
-  await queryClient.prefetchQuery({
-    queryKey: queryKeys.books.detail(id),
-    queryFn: async () => {
-      const data = await authenticatedRequest(`/books/${id}`);
-      return bookDetailSchema.parse(data);
-    },
-  });
+  await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: queryKeys.books.detail(id),
+      queryFn: async () => {
+        const data = await authenticatedRequest(`/books/${id}`);
+        return bookDetailSchema.parse(data);
+      },
+    }),
+    queryClient.prefetchQuery({
+      queryKey: queryKeys.profile.all,
+      queryFn: async () => {
+        const data = await authenticatedRequest('/profile');
+        return userSchema.parse(data);
+      },
+    }),
+  ]);
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/frontend/src/app/(protected)/books/_components/display/view/BookDetailView.tsx
+++ b/frontend/src/app/(protected)/books/_components/display/view/BookDetailView.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { BookDetail } from '@/app/(protected)/books/_types';
 import { useBookDetailView } from '@/app/(protected)/books/_hooks/useBookDetailView';
 import UpdateBookFormModal from '@/app/(protected)/books/_components/modal';
@@ -20,9 +21,12 @@ export default function BookDetailView({ book }: BookDetailProps) {
   const { breadcrumbItems, badges, handleDelete, updateModal, addListModal, cardModal } =
     useBookDetailView(book);
   const { data: profile } = useProfile();
+  const [isOwner, setIsOwner] = useState(false);
 
-  // ログインユーザーが本の所有者かどうかを判定
-  const isOwner = profile?.id === book.user_id;
+  // ハイドレーション後にオーナー判定を行い、サーバー/クライアントのミスマッチを防ぐ
+  useEffect(() => {
+    setIsOwner(profile?.id === book.user_id);
+  }, [profile?.id, book.user_id]);
 
   return (
     <>

--- a/frontend/src/app/(protected)/books/_lib/mutation/createBook.ts
+++ b/frontend/src/app/(protected)/books/_lib/mutation/createBook.ts
@@ -1,17 +1,5 @@
-import { BookBase, bookBaseSchema, BookCreateData } from '@/app/(protected)/books/_types';
+import { type BookBase, bookBaseSchema, type BookCreateData } from '@/app/(protected)/books/_types';
+import { mutateResource } from '@/lib/api/mutateResource';
 
-export async function createBook(data: BookCreateData): Promise<BookBase> {
-  const response = await fetch('/api/books', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-  });
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const res = await response.json();
-  return bookBaseSchema.parse(res);
-}
+export const createBook = (data: BookCreateData): Promise<BookBase> =>
+  mutateResource('/api/books', 'POST', data, bookBaseSchema);

--- a/frontend/src/app/(protected)/books/_lib/mutation/deleteBook.ts
+++ b/frontend/src/app/(protected)/books/_lib/mutation/deleteBook.ts
@@ -1,11 +1,4 @@
-export async function deleteBook({ id }: { id: string }): Promise<void> {
-  const response = await fetch(`/api/books/${id}`, {
-    method: 'DELETE',
-    headers: { 'Content-Type': 'application/json' },
-  });
+import { mutateResource } from '@/lib/api/mutateResource';
 
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-}
+export const deleteBook = ({ id }: { id: string }): Promise<void> =>
+  mutateResource(`/api/books/${id}`, 'DELETE');

--- a/frontend/src/app/(protected)/books/_lib/mutation/updateBook.ts
+++ b/frontend/src/app/(protected)/books/_lib/mutation/updateBook.ts
@@ -1,17 +1,5 @@
-import { BookBase, bookBaseSchema, BookUpdateData } from '@/app/(protected)/books/_types';
+import { type BookBase, bookBaseSchema, type BookUpdateData } from '@/app/(protected)/books/_types';
+import { mutateResource } from '@/lib/api/mutateResource';
 
-export async function updateBook(data: BookUpdateData): Promise<BookBase> {
-  const response = await fetch(`/api/books/${data.id}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-  });
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const res = await response.json();
-  return bookBaseSchema.parse(res);
-}
+export const updateBook = (data: BookUpdateData): Promise<BookBase> =>
+  mutateResource(`/api/books/${data.id}`, 'PUT', data, bookBaseSchema);

--- a/frontend/src/app/(protected)/books/_lib/query/fetchBook.ts
+++ b/frontend/src/app/(protected)/books/_lib/query/fetchBook.ts
@@ -1,17 +1,5 @@
 import { bookDetailSchema, type BookDetail } from '@/app/(protected)/books/_types';
+import { fetchResource } from '@/lib/api/fetchResource';
 
-/**
- * 書籍詳細を取得する
- * クライアントコンポーネント（useQuery）で使用
- */
-export async function fetchBook(id: string): Promise<BookDetail> {
-  const response = await fetch(`/api/books/${id}`);
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const data = await response.json();
-  return bookDetailSchema.parse(data);
-}
+export const fetchBook = (id: string): Promise<BookDetail> =>
+  fetchResource(`/api/books/${id}`, bookDetailSchema);

--- a/frontend/src/app/(protected)/books/_lib/query/fetchBooks.ts
+++ b/frontend/src/app/(protected)/books/_lib/query/fetchBooks.ts
@@ -1,17 +1,4 @@
 import { bookSchema, type Book } from '@/app/(protected)/books/_types';
+import { fetchResource } from '@/lib/api/fetchResource';
 
-/**
- * 書籍一覧を取得する
- * クライアントコンポーネント（useQuery）で使用
- */
-export async function fetchBooks(): Promise<Book[]> {
-  const response = await fetch('/api/books');
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const data = await response.json();
-  return bookSchema.array().parse(data);
-}
+export const fetchBooks = (): Promise<Book[]> => fetchResource('/api/books', bookSchema.array());

--- a/frontend/src/app/(protected)/books/loading.tsx
+++ b/frontend/src/app/(protected)/books/loading.tsx
@@ -1,0 +1,48 @@
+export default function BooksLoading() {
+  return (
+    <div className="max-w-4xl mx-auto">
+      {/* ページヘッダー */}
+      <header className="mb-6">
+        <div className="flex flex-wrap justify-between gap-3">
+          <div className="flex min-w-72 flex-col gap-2">
+            <div className="h-8 w-16 animate-pulse rounded bg-slate-200 mb-6" />
+            <div className="h-5 w-48 animate-pulse rounded bg-slate-200" />
+          </div>
+          <div className="flex items-end">
+            <div className="h-10 w-28 animate-pulse rounded-lg bg-slate-200" />
+          </div>
+        </div>
+      </header>
+
+      {/* カテゴリフィルター */}
+      <div className="flex gap-2 pb-6 border-b border-slate-200">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="h-8 w-20 shrink-0 animate-pulse rounded-full bg-slate-200" />
+        ))}
+      </div>
+
+      {/* 本のリスト */}
+      <div className="flex flex-col gap-4 mt-6">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="p-4 bg-white rounded-xl border border-slate-200">
+            <div className="flex flex-col sm:flex-row gap-4 sm:gap-6">
+              <div className="w-32 h-44 shrink-0 animate-pulse rounded-lg bg-slate-200" />
+              <div className="flex flex-col gap-3 flex-1">
+                <div className="h-5 w-3/4 animate-pulse rounded bg-slate-200" />
+                <div className="flex flex-col gap-1">
+                  <div className="h-4 w-1/2 animate-pulse rounded bg-slate-200" />
+                  <div className="h-4 w-1/3 animate-pulse rounded bg-slate-200" />
+                </div>
+                <div className="h-4 w-full animate-pulse rounded bg-slate-200" />
+                <div className="flex gap-2">
+                  <div className="h-5 w-16 animate-pulse rounded-full bg-slate-200" />
+                  <div className="h-5 w-14 animate-pulse rounded-full bg-slate-200" />
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(protected)/cards/[id]/loading.tsx
+++ b/frontend/src/app/(protected)/cards/[id]/loading.tsx
@@ -1,0 +1,48 @@
+export default function CardDetailLoading() {
+  return (
+    <div className="flex flex-col gap-8">
+      {/* パンくずリスト */}
+      <nav className="flex flex-wrap items-center gap-2 min-w-0">
+        <div className="h-4 w-20 animate-pulse rounded bg-slate-200" />
+        <span className="text-slate-400">/</span>
+        <div className="h-4 w-24 animate-pulse rounded bg-slate-200" />
+      </nav>
+
+      {/* メインカード */}
+      <div className="flex flex-col sm:flex-row gap-6 p-6 sm:p-8 bg-white rounded-xl border border-slate-200">
+        <div className="flex flex-1 flex-col gap-6 min-w-0">
+          {/* ヘッダー */}
+          <div className="flex flex-wrap justify-between items-start gap-4 min-w-0">
+            <div className="flex flex-col gap-1 flex-1 min-w-0">
+              <div className="h-9 w-3/4 animate-pulse rounded bg-slate-200" />
+              <div className="h-5 w-1/2 animate-pulse rounded bg-slate-200" />
+            </div>
+            <div className="flex items-center gap-3">
+              <div className="h-6 w-20 animate-pulse rounded-full bg-slate-200" />
+            </div>
+          </div>
+
+          {/* 説明 */}
+          <div className="flex flex-col gap-1">
+            <div className="h-4 w-full animate-pulse rounded bg-slate-200" />
+            <div className="h-4 w-5/6 animate-pulse rounded bg-slate-200" />
+            <div className="h-4 w-2/3 animate-pulse rounded bg-slate-200" />
+          </div>
+
+          {/* メタデータ */}
+          <div className="flex flex-wrap gap-x-6 gap-y-2 pt-2 border-t border-slate-200">
+            <div className="h-4 w-32 animate-pulse rounded bg-slate-200" />
+            <div className="h-4 w-32 animate-pulse rounded bg-slate-200" />
+          </div>
+
+          {/* アクションボタン */}
+          <div className="flex flex-wrap gap-3 pt-4">
+            <div className="h-10 w-24 animate-pulse rounded-lg bg-slate-200" />
+            <div className="h-10 w-28 animate-pulse rounded-lg bg-slate-200" />
+            <div className="ml-auto h-10 w-20 animate-pulse rounded-lg bg-slate-200" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(protected)/cards/_components/display/BookCardGroup.tsx
+++ b/frontend/src/app/(protected)/cards/_components/display/BookCardGroup.tsx
@@ -4,8 +4,7 @@ import { useState } from 'react';
 import { Card } from '@/app/(protected)/cards/_types';
 import CardItem from '@/app/(protected)/cards/_components/display/CardItem';
 import CardModal from '@/app/(protected)/cards/_components/modal';
-import Button from '@/components/buttons/Button';
-import { StickyNote, ChevronDown, ChevronUp } from 'lucide-react';
+import { ChevronDown, ChevronUp, Plus } from 'lucide-react';
 import { useModal } from '@/hooks/useModal';
 
 interface BookCardGroupProps {
@@ -25,37 +24,34 @@ export default function BookCardGroup({ book, cards }: BookCardGroupProps) {
   };
 
   return (
-    <section className="space-y-4">
+    <section className="space-y-3">
       {/* 本のタイトルと作成ボタン */}
-      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
-        <div className="flex items-center gap-2 flex-1 min-w-0">
-          {/* 展開/折りたたみボタン */}
-          <button
-            onClick={toggleExpand}
-            className="flex-shrink-0 p-1 hover:bg-gray-100 rounded transition-colors cursor-pointer"
-            data-testid="expand"
-            aria-label={isExpanded ? 'カードリストを折りたたむ' : 'カードリストを展開する'}
-            aria-expanded={isExpanded}
-          >
-            {isExpanded ? (
-              <ChevronUp size={24} className="text-gray-600" />
-            ) : (
-              <ChevronDown size={24} className="text-gray-600" />
-            )}
-          </button>
-
-          <h2 className="text-xl font-bold text-gray-900 truncate">{book.title}</h2>
-
-          <span className="text-sm text-gray-500 flex-shrink-0">({cards.length}枚)</span>
-        </div>
-
-        <Button
-          variant="primary"
-          onClick={cardModal.open}
-          icon={<StickyNote className="h-4 w-4" />}
+      <div className="flex items-center gap-2 max-w-full">
+        <button
+          onClick={toggleExpand}
+          className="flex-shrink-0 p-1 hover:bg-gray-100 rounded transition-colors cursor-pointer"
+          data-testid="expand"
+          aria-label={isExpanded ? 'カードリストを折りたたむ' : 'カードリストを展開する'}
+          aria-expanded={isExpanded}
         >
-          カードを作成
-        </Button>
+          {isExpanded ? (
+            <ChevronUp size={20} className="text-gray-500" />
+          ) : (
+            <ChevronDown size={20} className="text-gray-500" />
+          )}
+        </button>
+
+        <h2 className="text-lg font-bold text-gray-900 truncate min-w-0">{book.title}</h2>
+
+        <span className="text-sm text-gray-500 flex-shrink-0">({cards.length}枚)</span>
+
+        <button
+          onClick={cardModal.open}
+          className="flex-shrink-0 ml-auto p-1.5 text-primary hover:bg-primary/10 rounded-lg transition-colors cursor-pointer"
+          aria-label="カードを作成"
+        >
+          <Plus size={20} />
+        </button>
       </div>
 
       {/* カードのリスト（アコーディオン） */}
@@ -65,11 +61,11 @@ export default function BookCardGroup({ book, cards }: BookCardGroupProps) {
         }`}
       >
         {cards.length === 0 ? (
-          <div className="rounded-lg border border-gray-200 bg-white p-8 text-center">
-            <p className="text-sm text-gray-500">この本にはまだカードが登録されていません</p>
-          </div>
+          <p className="text-sm text-gray-500 pl-8 py-2">
+            この本にはまだカードが登録されていません
+          </p>
         ) : (
-          <div className="rounded-lg border border-gray-200 bg-white">
+          <div className="space-y-3 pl-8">
             {cards.map((card) => (
               <CardItem key={card.id} card={card} />
             ))}

--- a/frontend/src/app/(protected)/cards/_components/display/CardItem.tsx
+++ b/frontend/src/app/(protected)/cards/_components/display/CardItem.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Flag } from 'lucide-react';
 import { Card } from '@/app/(protected)/cards/_types';
 import Button from '@/components/buttons/Button';
 import StatusBadge from '@/components/badges/StatusBadge';
@@ -15,26 +14,23 @@ export default function CardItem({ card }: CardItemProps) {
   const { handleDelete } = useCardItem(card);
 
   return (
-    <div className="border-b border-gray-200 p-4 last:border-b-0">
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-        <div className="flex-1 min-w-0">
-          {/* タイトル */}
-          <h3 className="text-base font-semibold text-gray-900 mb-2 truncate">{card.title}</h3>
-
-          {/* 本文 */}
-          <p className="text-sm text-gray-600 whitespace-pre-wrap mb-2">{card.content}</p>
-
-          {/* ステータス */}
+    <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="flex flex-col gap-3">
+        {/* ヘッダー: タイトルとステータス */}
+        <div className="flex items-start justify-between gap-3">
+          <h3 className="text-base font-semibold text-gray-900 truncate min-w-0">{card.title}</h3>
           {card.status && (
-            <div className="inline-flex items-center gap-2">
-              <Flag size={16} className="text-gray-500" />
+            <div className="flex-shrink-0">
               <StatusBadge label={card.status.name} />
             </div>
           )}
         </div>
 
+        {/* 本文 */}
+        <p className="text-sm text-gray-600 line-clamp-2">{card.content}</p>
+
         {/* アクションボタン */}
-        <div className="flex-shrink-0 flex gap-2 justify-center sm:justify-start items-center">
+        <div className="flex items-center gap-2 pt-1">
           <DetailLink href={`/cards/${card.id}`} />
           <Button variant="danger" onClick={handleDelete}>
             削除

--- a/frontend/src/app/(protected)/cards/_lib/mutation/createCard.ts
+++ b/frontend/src/app/(protected)/cards/_lib/mutation/createCard.ts
@@ -1,17 +1,5 @@
-import { Card, CardFormData, cardSchema } from '@/app/(protected)/cards/_types';
+import { type Card, type CardFormData, cardSchema } from '@/app/(protected)/cards/_types';
+import { mutateResource } from '@/lib/api/mutateResource';
 
-export async function createCard(data: CardFormData): Promise<Card> {
-  const response = await fetch(`/api/books/${data.book_id}/cards`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-  });
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const res = await response.json();
-  return cardSchema.parse(res);
-}
+export const createCard = (data: CardFormData): Promise<Card> =>
+  mutateResource(`/api/books/${data.book_id}/cards`, 'POST', data, cardSchema);

--- a/frontend/src/app/(protected)/cards/_lib/mutation/deleteCard.ts
+++ b/frontend/src/app/(protected)/cards/_lib/mutation/deleteCard.ts
@@ -1,17 +1,4 @@
-export async function deleteCard({
-  bookId,
-  cardId,
-}: {
-  bookId: string;
-  cardId: string;
-}): Promise<void> {
-  const response = await fetch(`/api/books/${bookId}/cards/${cardId}`, {
-    method: 'DELETE',
-    headers: { 'Content-Type': 'application/json' },
-  });
+import { mutateResource } from '@/lib/api/mutateResource';
 
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-}
+export const deleteCard = ({ bookId, cardId }: { bookId: string; cardId: string }): Promise<void> =>
+  mutateResource(`/api/books/${bookId}/cards/${cardId}`, 'DELETE');

--- a/frontend/src/app/(protected)/cards/_lib/mutation/updateCard.ts
+++ b/frontend/src/app/(protected)/cards/_lib/mutation/updateCard.ts
@@ -1,20 +1,7 @@
-import { Card, CardFormData, cardSchema } from '@/app/(protected)/cards/_types';
+import { type Card, type CardFormData, cardSchema } from '@/app/(protected)/cards/_types';
+import { mutateResource } from '@/lib/api/mutateResource';
 
-// 更新用の型
 type UpdateCardData = CardFormData & { id: string };
 
-export async function updateCard(data: UpdateCardData): Promise<Card> {
-  const response = await fetch(`/api/books/${data.book_id}/cards/${data.id}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-  });
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const res = await response.json();
-  return cardSchema.parse(res);
-}
+export const updateCard = (data: UpdateCardData): Promise<Card> =>
+  mutateResource(`/api/books/${data.book_id}/cards/${data.id}`, 'PUT', data, cardSchema);

--- a/frontend/src/app/(protected)/cards/_lib/query/fetchCard.ts
+++ b/frontend/src/app/(protected)/cards/_lib/query/fetchCard.ts
@@ -1,17 +1,5 @@
 import { cardDetailSchema, type CardDetail } from '@/app/(protected)/cards/_types';
+import { fetchResource } from '@/lib/api/fetchResource';
 
-/**
- * カード詳細を取得する
- * クライアントコンポーネント（useQuery）で使用
- */
-export async function fetchCard(id: string): Promise<CardDetail> {
-  const response = await fetch(`/api/cards/${id}`);
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const data = await response.json();
-  return cardDetailSchema.parse(data);
-}
+export const fetchCard = (id: string): Promise<CardDetail> =>
+  fetchResource(`/api/cards/${id}`, cardDetailSchema);

--- a/frontend/src/app/(protected)/cards/_lib/query/fetchCards.ts
+++ b/frontend/src/app/(protected)/cards/_lib/query/fetchCards.ts
@@ -1,17 +1,4 @@
 import { cardListSchema, type CardList } from '@/app/(protected)/cards/_types';
+import { fetchResource } from '@/lib/api/fetchResource';
 
-/**
- * カード一覧を取得する
- * クライアントコンポーネント（useQuery）で使用
- */
-export async function fetchCards(): Promise<CardList> {
-  const response = await fetch('/api/cards');
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const data = await response.json();
-  return cardListSchema.parse(data);
-}
+export const fetchCards = (): Promise<CardList> => fetchResource('/api/cards', cardListSchema);

--- a/frontend/src/app/(protected)/cards/loading.tsx
+++ b/frontend/src/app/(protected)/cards/loading.tsx
@@ -1,0 +1,29 @@
+export default function CardsLoading() {
+  return (
+    <div className="flex flex-col gap-8">
+      {/* ページタイトル */}
+      <div className="h-8 w-28 animate-pulse rounded bg-slate-200 mb-6" />
+
+      {/* フィルター */}
+      <div className="flex gap-2 pb-6 border-b border-slate-200">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="h-8 w-20 shrink-0 animate-pulse rounded-full bg-slate-200" />
+        ))}
+      </div>
+
+      {/* 本ごとのカードグループ */}
+      {Array.from({ length: 3 }).map((_, i) => (
+        <section key={i} className="space-y-4">
+          <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
+            <div className="flex items-center gap-2 flex-1 min-w-0">
+              <div className="h-6 w-6 shrink-0 animate-pulse rounded bg-slate-200" />
+              <div className="h-6 w-48 animate-pulse rounded bg-slate-200" />
+              <div className="h-4 w-10 shrink-0 animate-pulse rounded bg-slate-200" />
+            </div>
+            <div className="h-10 w-32 animate-pulse rounded-lg bg-slate-200" />
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/app/(protected)/categories/_lib/mutation/createCategory.ts
+++ b/frontend/src/app/(protected)/categories/_lib/mutation/createCategory.ts
@@ -1,4 +1,8 @@
-import { type Category, type CategoryFormData, categorySchema } from '@/app/(protected)/categories/_types';
+import {
+  type Category,
+  type CategoryFormData,
+  categorySchema,
+} from '@/app/(protected)/categories/_types';
 import { mutateResource } from '@/lib/api/mutateResource';
 
 export const createCategory = (data: CategoryFormData): Promise<Category> =>

--- a/frontend/src/app/(protected)/categories/_lib/mutation/createCategory.ts
+++ b/frontend/src/app/(protected)/categories/_lib/mutation/createCategory.ts
@@ -1,17 +1,5 @@
-import { Category, CategoryFormData, categorySchema } from '@/app/(protected)/categories/_types';
+import { type Category, type CategoryFormData, categorySchema } from '@/app/(protected)/categories/_types';
+import { mutateResource } from '@/lib/api/mutateResource';
 
-export async function createCategory(data: CategoryFormData): Promise<Category> {
-  const response = await fetch('/api/categories', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-  });
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const res = await response.json();
-  return categorySchema.parse(res);
-}
+export const createCategory = (data: CategoryFormData): Promise<Category> =>
+  mutateResource('/api/categories', 'POST', data, categorySchema);

--- a/frontend/src/app/(protected)/categories/_lib/mutation/deleteCategory.ts
+++ b/frontend/src/app/(protected)/categories/_lib/mutation/deleteCategory.ts
@@ -1,11 +1,4 @@
-export async function deleteCategory(id: number): Promise<void> {
-  const response = await fetch(`/api/categories/${id}`, {
-    method: 'DELETE',
-    headers: { 'Content-Type': 'application/json' },
-  });
+import { mutateResource } from '@/lib/api/mutateResource';
 
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-}
+export const deleteCategory = (id: number): Promise<void> =>
+  mutateResource(`/api/categories/${id}`, 'DELETE');

--- a/frontend/src/app/(protected)/categories/_lib/mutation/updateCategory.ts
+++ b/frontend/src/app/(protected)/categories/_lib/mutation/updateCategory.ts
@@ -1,24 +1,12 @@
-import { Category, categorySchema } from '@/app/(protected)/categories/_types';
+import { type Category, categorySchema } from '@/app/(protected)/categories/_types';
+import { mutateResource } from '@/lib/api/mutateResource';
 
-// 更新用の型
 export interface UpdateCategoryData {
   id: number;
   name: string;
 }
 
-export async function updateCategory(data: UpdateCategoryData): Promise<Category> {
+export const updateCategory = (data: UpdateCategoryData): Promise<Category> => {
   const { id, ...updateData } = data;
-  const response = await fetch(`/api/categories/${id}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(updateData),
-  });
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const res = await response.json();
-  return categorySchema.parse(res);
-}
+  return mutateResource(`/api/categories/${id}`, 'PUT', updateData, categorySchema);
+};

--- a/frontend/src/app/(protected)/categories/_lib/query/fetchCategories.ts
+++ b/frontend/src/app/(protected)/categories/_lib/query/fetchCategories.ts
@@ -1,17 +1,5 @@
 import { categorySchema, type Category } from '@/app/(protected)/categories/_types';
+import { fetchResource } from '@/lib/api/fetchResource';
 
-/**
- * カテゴリ一覧を取得する
- * クライアントコンポーネント（useQuery）で使用
- */
-export async function fetchCategories(): Promise<Category[]> {
-  const response = await fetch('/api/categories');
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const data = await response.json();
-  return categorySchema.array().parse(data);
-}
+export const fetchCategories = (): Promise<Category[]> =>
+  fetchResource('/api/categories', categorySchema.array());

--- a/frontend/src/app/(protected)/dashboard/_lib/query/fetchDashboard.ts
+++ b/frontend/src/app/(protected)/dashboard/_lib/query/fetchDashboard.ts
@@ -1,13 +1,5 @@
 import { dashboardSchema, type Dashboard } from '@/schemas/dashboard';
+import { fetchResource } from '@/lib/api/fetchResource';
 
-export async function fetchDashboard(): Promise<Dashboard> {
-  const response = await fetch('/api/dashboard');
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const data = await response.json();
-  return dashboardSchema.parse(data);
-}
+export const fetchDashboard = (): Promise<Dashboard> =>
+  fetchResource('/api/dashboard', dashboardSchema);

--- a/frontend/src/app/(protected)/dashboard/loading.tsx
+++ b/frontend/src/app/(protected)/dashboard/loading.tsx
@@ -1,0 +1,26 @@
+export default function DashboardLoading() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      {/* ページタイトル */}
+      <div className="mb-8">
+        <div className="h-10 w-48 animate-pulse rounded-lg bg-slate-200" />
+      </div>
+
+      {/* 概要統計 */}
+      <section className="mb-8">
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-24 animate-pulse rounded-lg bg-slate-200" />
+          ))}
+        </div>
+      </section>
+
+      {/* グラフエリア */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="h-64 animate-pulse rounded-lg bg-slate-200" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(protected)/dashboard/loading.tsx
+++ b/frontend/src/app/(protected)/dashboard/loading.tsx
@@ -2,15 +2,21 @@ export default function DashboardLoading() {
   return (
     <div className="container mx-auto px-4 py-8">
       {/* ページタイトル */}
-      <div className="mb-8">
-        <div className="h-10 w-48 animate-pulse rounded-lg bg-slate-200" />
-      </div>
+      <div className="h-8 w-40 animate-pulse rounded bg-slate-200 mb-6" />
 
       {/* 概要統計 */}
       <section className="mb-8">
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
           {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="h-24 animate-pulse rounded-lg bg-slate-200" />
+            <div key={i} className="bg-white rounded-lg shadow p-6 border border-gray-200">
+              <div className="flex items-center justify-between">
+                <div className="flex flex-col gap-2">
+                  <div className="h-4 w-20 animate-pulse rounded bg-slate-200" />
+                  <div className="h-8 w-12 animate-pulse rounded bg-slate-200" />
+                </div>
+                <div className="h-12 w-12 animate-pulse rounded-full bg-slate-200" />
+              </div>
+            </div>
           ))}
         </div>
       </section>
@@ -18,7 +24,10 @@ export default function DashboardLoading() {
       {/* グラフエリア */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
         {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="h-64 animate-pulse rounded-lg bg-slate-200" />
+          <div key={i} className="bg-white rounded-lg shadow p-6 border border-gray-200">
+            <div className="h-5 w-40 animate-pulse rounded bg-slate-200 mb-4" />
+            <div className="h-[300px] animate-pulse rounded bg-slate-200" />
+          </div>
         ))}
       </div>
     </div>

--- a/frontend/src/app/(protected)/listBooks/_lib/mutation/addListBook.ts
+++ b/frontend/src/app/(protected)/listBooks/_lib/mutation/addListBook.ts
@@ -1,17 +1,5 @@
-import { ListBook, ListBookFormData, listBookSchema } from '@/app/(protected)/listBooks/_types';
+import { type ListBook, type ListBookFormData, listBookSchema } from '@/app/(protected)/listBooks/_types';
+import { mutateResource } from '@/lib/api/mutateResource';
 
-export async function addListBook(data: ListBookFormData): Promise<ListBook> {
-  const response = await fetch('/api/list_books', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-  });
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const res = await response.json();
-  return listBookSchema.parse(res);
-}
+export const addListBook = (data: ListBookFormData): Promise<ListBook> =>
+  mutateResource('/api/list_books', 'POST', data, listBookSchema);

--- a/frontend/src/app/(protected)/listBooks/_lib/mutation/addListBook.ts
+++ b/frontend/src/app/(protected)/listBooks/_lib/mutation/addListBook.ts
@@ -1,4 +1,8 @@
-import { type ListBook, type ListBookFormData, listBookSchema } from '@/app/(protected)/listBooks/_types';
+import {
+  type ListBook,
+  type ListBookFormData,
+  listBookSchema,
+} from '@/app/(protected)/listBooks/_types';
 import { mutateResource } from '@/lib/api/mutateResource';
 
 export const addListBook = (data: ListBookFormData): Promise<ListBook> =>

--- a/frontend/src/app/(protected)/listBooks/_lib/mutation/removeListBook.ts
+++ b/frontend/src/app/(protected)/listBooks/_lib/mutation/removeListBook.ts
@@ -1,10 +1,4 @@
-export async function removeListBook({ id }: { id: number }): Promise<void> {
-  const response = await fetch(`/api/list_books/${id}`, {
-    method: 'DELETE',
-  });
+import { mutateResource } from '@/lib/api/mutateResource';
 
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-}
+export const removeListBook = ({ id }: { id: number }): Promise<void> =>
+  mutateResource(`/api/list_books/${id}`, 'DELETE');

--- a/frontend/src/app/(protected)/lists/[id]/loading.tsx
+++ b/frontend/src/app/(protected)/lists/[id]/loading.tsx
@@ -1,0 +1,60 @@
+export default function ListDetailLoading() {
+  return (
+    <div className="flex flex-col gap-8">
+      {/* パンくずリスト */}
+      <nav className="flex flex-wrap items-center gap-2 min-w-0">
+        <div className="h-4 w-16 animate-pulse rounded bg-slate-200" />
+        <span className="text-slate-400">/</span>
+        <div className="h-4 w-24 animate-pulse rounded bg-slate-200" />
+      </nav>
+
+      {/* メインカード */}
+      <div className="flex flex-col sm:flex-row gap-6 p-6 sm:p-8 bg-white rounded-xl border border-slate-200">
+        <div className="flex flex-1 flex-col gap-6 min-w-0">
+          {/* ヘッダー */}
+          <div className="flex flex-wrap justify-between items-start gap-4 min-w-0">
+            <div className="flex flex-col gap-1 flex-1 min-w-0">
+              <div className="h-9 w-3/4 animate-pulse rounded bg-slate-200" />
+            </div>
+            <div className="flex items-center gap-3">
+              <div className="h-6 w-16 animate-pulse rounded-full bg-slate-200" />
+            </div>
+          </div>
+
+          {/* 説明 */}
+          <div className="flex flex-col gap-1">
+            <div className="h-4 w-full animate-pulse rounded bg-slate-200" />
+            <div className="h-4 w-2/3 animate-pulse rounded bg-slate-200" />
+          </div>
+
+          {/* メタデータ */}
+          <div className="flex flex-wrap gap-x-6 gap-y-2 pt-2 border-t border-slate-200">
+            <div className="h-4 w-32 animate-pulse rounded bg-slate-200" />
+            <div className="h-4 w-32 animate-pulse rounded bg-slate-200" />
+          </div>
+
+          {/* アクションボタン */}
+          <div className="flex flex-wrap gap-3 pt-4">
+            <div className="h-10 w-24 animate-pulse rounded-lg bg-slate-200" />
+            <div className="h-10 w-28 animate-pulse rounded-lg bg-slate-200" />
+            <div className="ml-auto h-10 w-20 animate-pulse rounded-lg bg-slate-200" />
+          </div>
+        </div>
+      </div>
+
+      {/* 追加済みの本 */}
+      <div className="flex flex-col gap-4">
+        <div className="h-6 w-28 animate-pulse rounded bg-slate-200" />
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="flex gap-4 rounded-lg border border-slate-200 bg-white p-4">
+            <div className="w-16 h-22 shrink-0 animate-pulse rounded bg-slate-200" />
+            <div className="flex flex-col gap-2 flex-1">
+              <div className="h-5 w-3/4 animate-pulse rounded bg-slate-200" />
+              <div className="h-4 w-1/2 animate-pulse rounded bg-slate-200" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(protected)/lists/[id]/page.tsx
+++ b/frontend/src/app/(protected)/lists/[id]/page.tsx
@@ -4,6 +4,7 @@ import { queryKeys } from '@/constants/queryKeys';
 import ListDetailClient from '@/app/(protected)/lists/_components/clients/ListDetailClient';
 import { authenticatedRequest } from '@/supabase/dal';
 import { listDetailSchema } from '@/app/(protected)/lists/_types';
+import { userSchema } from '@/schemas/user';
 
 type Props = {
   params: Promise<{ id: string }>;
@@ -14,13 +15,22 @@ export default async function ListPage({ params }: Props) {
 
   const queryClient = createServerQueryClient();
 
-  await queryClient.prefetchQuery({
-    queryKey: queryKeys.lists.detail(id),
-    queryFn: async () => {
-      const data = await authenticatedRequest(`/lists/${id}`);
-      return listDetailSchema.parse(data);
-    },
-  });
+  await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: queryKeys.lists.detail(id),
+      queryFn: async () => {
+        const data = await authenticatedRequest(`/lists/${id}`);
+        return listDetailSchema.parse(data);
+      },
+    }),
+    queryClient.prefetchQuery({
+      queryKey: queryKeys.profile.all,
+      queryFn: async () => {
+        const data = await authenticatedRequest('/profile');
+        return userSchema.parse(data);
+      },
+    }),
+  ]);
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/frontend/src/app/(protected)/lists/_components/display/view/ListDetailView.tsx
+++ b/frontend/src/app/(protected)/lists/_components/display/view/ListDetailView.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { useListDetailView } from '@/app/(protected)/lists/_hooks/useListDetailView';
 import UpdateListFormModal from '@/app/(protected)/lists/_components/modal';
 import AddBookModal from '@/app/(protected)/listBooks/_components/modal/AddBookModal';
@@ -18,9 +19,12 @@ export default function ListDetailView({ list }: ListDetailProps) {
   const { breadcrumbItems, badges, handleDelete, updateModal, addBookModal } =
     useListDetailView(list);
   const { data: profile } = useProfile();
+  const [isOwner, setIsOwner] = useState(false);
 
-  // ログインユーザーがリストの所有者かどうかを判定
-  const isOwner = profile?.id === list.user_id;
+  // ハイドレーション後にオーナー判定を行い、サーバー/クライアントのミスマッチを防ぐ
+  useEffect(() => {
+    setIsOwner(profile?.id === list.user_id);
+  }, [profile?.id, list.user_id]);
 
   return (
     <>

--- a/frontend/src/app/(protected)/lists/_lib/mutation/createList.ts
+++ b/frontend/src/app/(protected)/lists/_lib/mutation/createList.ts
@@ -1,17 +1,5 @@
-import { ListBase, listBaseSchema, ListFormData } from '@/app/(protected)/lists/_types';
+import { type ListBase, listBaseSchema, type ListFormData } from '@/app/(protected)/lists/_types';
+import { mutateResource } from '@/lib/api/mutateResource';
 
-export async function createList(data: ListFormData): Promise<ListBase> {
-  const response = await fetch('/api/lists', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-  });
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const res = await response.json();
-  return listBaseSchema.parse(res);
-}
+export const createList = (data: ListFormData): Promise<ListBase> =>
+  mutateResource('/api/lists', 'POST', data, listBaseSchema);

--- a/frontend/src/app/(protected)/lists/_lib/mutation/deleteList.ts
+++ b/frontend/src/app/(protected)/lists/_lib/mutation/deleteList.ts
@@ -1,11 +1,4 @@
-export async function deleteList(id: string): Promise<void> {
-  const response = await fetch(`/api/lists/${id}`, {
-    method: 'DELETE',
-    headers: { 'Content-Type': 'application/json' },
-  });
+import { mutateResource } from '@/lib/api/mutateResource';
 
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-}
+export const deleteList = (id: string): Promise<void> =>
+  mutateResource(`/api/lists/${id}`, 'DELETE');

--- a/frontend/src/app/(protected)/lists/_lib/mutation/updateList.ts
+++ b/frontend/src/app/(protected)/lists/_lib/mutation/updateList.ts
@@ -1,6 +1,6 @@
-import { ListBase, listBaseSchema } from '@/app/(protected)/lists/_types';
+import { type ListBase, listBaseSchema } from '@/app/(protected)/lists/_types';
+import { mutateResource } from '@/lib/api/mutateResource';
 
-// 更新用の型
 export interface UpdateListData {
   id: string;
   name: string;
@@ -8,19 +8,7 @@ export interface UpdateListData {
   public: boolean;
 }
 
-export async function updateList(data: UpdateListData): Promise<ListBase> {
+export const updateList = (data: UpdateListData): Promise<ListBase> => {
   const { id, ...updateData } = data;
-  const response = await fetch(`/api/lists/${id}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(updateData),
-  });
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const res = await response.json();
-  return listBaseSchema.parse(res);
-}
+  return mutateResource(`/api/lists/${id}`, 'PUT', updateData, listBaseSchema);
+};

--- a/frontend/src/app/(protected)/lists/_lib/query/fetchList.ts
+++ b/frontend/src/app/(protected)/lists/_lib/query/fetchList.ts
@@ -1,17 +1,5 @@
 import { listDetailSchema, type ListDetail } from '@/app/(protected)/lists/_types';
+import { fetchResource } from '@/lib/api/fetchResource';
 
-/**
- * リスト詳細を取得する
- * クライアントコンポーネント（useQuery）で使用
- */
-export async function fetchList(id: string): Promise<ListDetail> {
-  const response = await fetch(`/api/lists/${id}`);
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const data = await response.json();
-  return listDetailSchema.parse(data);
-}
+export const fetchList = (id: string): Promise<ListDetail> =>
+  fetchResource(`/api/lists/${id}`, listDetailSchema);

--- a/frontend/src/app/(protected)/lists/_lib/query/fetchLists.ts
+++ b/frontend/src/app/(protected)/lists/_lib/query/fetchLists.ts
@@ -1,17 +1,4 @@
 import { listSchema, type List } from '@/app/(protected)/lists/_types';
+import { fetchResource } from '@/lib/api/fetchResource';
 
-/**
- * リスト一覧を取得する
- * クライアントコンポーネント（useQuery）で使用
- */
-export async function fetchLists(): Promise<List[]> {
-  const response = await fetch('/api/lists');
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const data = await response.json();
-  return listSchema.array().parse(data);
-}
+export const fetchLists = (): Promise<List[]> => fetchResource('/api/lists', listSchema.array());

--- a/frontend/src/app/(protected)/lists/loading.tsx
+++ b/frontend/src/app/(protected)/lists/loading.tsx
@@ -1,0 +1,40 @@
+export default function ListsLoading() {
+  return (
+    <>
+      {/* ページタイトル */}
+      <div className="h-8 w-28 animate-pulse rounded bg-slate-200 mb-6" />
+
+      {/* 新規作成ボタン */}
+      <div className="mb-6 flex justify-end">
+        <div className="h-10 w-40 animate-pulse rounded-lg bg-slate-200" />
+      </div>
+
+      {/* リストカード */}
+      <div className="space-y-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="rounded-lg border border-slate-200 bg-white p-4">
+            <div className="flex flex-col sm:flex-row gap-4">
+              {/* ブックマークアイコン */}
+              <div className="shrink-0 w-12 h-12 animate-pulse rounded-lg bg-slate-200" />
+
+              {/* リスト情報 */}
+              <div className="flex flex-col gap-2 min-w-0 flex-1">
+                <div className="h-5 w-3/4 animate-pulse rounded bg-slate-200" />
+                <div className="h-4 w-full animate-pulse rounded bg-slate-200" />
+                <div className="flex flex-wrap items-center gap-4">
+                  <div className="h-3 w-20 animate-pulse rounded bg-slate-200" />
+                  <div className="h-3 w-28 animate-pulse rounded bg-slate-200" />
+                </div>
+              </div>
+
+              {/* 詳細ボタン */}
+              <div className="sm:self-end sm:ml-auto">
+                <div className="h-10 w-full sm:w-16 animate-pulse rounded-lg bg-slate-200" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/frontend/src/app/(protected)/settings/_lib/mutation/updateProfile.ts
+++ b/frontend/src/app/(protected)/settings/_lib/mutation/updateProfile.ts
@@ -1,17 +1,5 @@
-import { User, UserFormData, userSchema } from '@/schemas/user';
+import { type User, type UserFormData, userSchema } from '@/schemas/user';
+import { mutateResource } from '@/lib/api/mutateResource';
 
-export async function updateProfile(data: UserFormData): Promise<User> {
-  const response = await fetch('/api/profiles', {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-  });
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const res = await response.json();
-  return userSchema.parse(res);
-}
+export const updateProfile = (data: UserFormData): Promise<User> =>
+  mutateResource('/api/profiles', 'PUT', data, userSchema);

--- a/frontend/src/app/(protected)/statuses/_lib/mutation/createStatus.ts
+++ b/frontend/src/app/(protected)/statuses/_lib/mutation/createStatus.ts
@@ -1,17 +1,5 @@
-import { Status, StatusFormData, statusSchema } from '@/app/(protected)/statuses/_types';
+import { type Status, type StatusFormData, statusSchema } from '@/app/(protected)/statuses/_types';
+import { mutateResource } from '@/lib/api/mutateResource';
 
-export async function createStatus(data: StatusFormData): Promise<Status> {
-  const response = await fetch('/api/statuses', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-  });
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const res = await response.json();
-  return statusSchema.parse(res);
-}
+export const createStatus = (data: StatusFormData): Promise<Status> =>
+  mutateResource('/api/statuses', 'POST', data, statusSchema);

--- a/frontend/src/app/(protected)/statuses/_lib/mutation/deleteStatus.ts
+++ b/frontend/src/app/(protected)/statuses/_lib/mutation/deleteStatus.ts
@@ -1,10 +1,4 @@
-export async function deleteStatus(id: number): Promise<void> {
-  const response = await fetch(`/api/statuses/${id}`, {
-    method: 'DELETE',
-  });
+import { mutateResource } from '@/lib/api/mutateResource';
 
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-}
+export const deleteStatus = (id: number): Promise<void> =>
+  mutateResource(`/api/statuses/${id}`, 'DELETE');

--- a/frontend/src/app/(protected)/statuses/_lib/mutation/updateStatus.ts
+++ b/frontend/src/app/(protected)/statuses/_lib/mutation/updateStatus.ts
@@ -1,20 +1,9 @@
-import { Status, StatusFormData, statusSchema } from '@/app/(protected)/statuses/_types';
+import { type Status, type StatusFormData, statusSchema } from '@/app/(protected)/statuses/_types';
+import { mutateResource } from '@/lib/api/mutateResource';
 
 export type UpdateStatusData = StatusFormData & { id: number };
 
-export async function updateStatus(data: UpdateStatusData): Promise<Status> {
+export const updateStatus = (data: UpdateStatusData): Promise<Status> => {
   const { id, ...updateData } = data;
-  const response = await fetch(`/api/statuses/${id}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(updateData),
-  });
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const res = await response.json();
-  return statusSchema.parse(res);
-}
+  return mutateResource(`/api/statuses/${id}`, 'PUT', updateData, statusSchema);
+};

--- a/frontend/src/app/(protected)/statuses/_lib/query/fetchStatuses.ts
+++ b/frontend/src/app/(protected)/statuses/_lib/query/fetchStatuses.ts
@@ -1,13 +1,5 @@
 import { statusSchema, type Status } from '@/app/(protected)/statuses/_types';
+import { fetchResource } from '@/lib/api/fetchResource';
 
-export async function fetchStatuses(): Promise<Status[]> {
-  const response = await fetch('/api/statuses');
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const data = await response.json();
-  return statusSchema.array().parse(data);
-}
+export const fetchStatuses = (): Promise<Status[]> =>
+  fetchResource('/api/statuses', statusSchema.array());

--- a/frontend/src/app/(protected)/tags/_lib/mutation/createTag.ts
+++ b/frontend/src/app/(protected)/tags/_lib/mutation/createTag.ts
@@ -1,17 +1,5 @@
-import { Tag, TagFormData, tagSchema } from '@/app/(protected)/tags/_types';
+import { type Tag, type TagFormData, tagSchema } from '@/app/(protected)/tags/_types';
+import { mutateResource } from '@/lib/api/mutateResource';
 
-export async function createTag(data: TagFormData): Promise<Tag> {
-  const response = await fetch('/api/tags', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-  });
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const res = await response.json();
-  return tagSchema.parse(res);
-}
+export const createTag = (data: TagFormData): Promise<Tag> =>
+  mutateResource('/api/tags', 'POST', data, tagSchema);

--- a/frontend/src/app/(protected)/tags/_lib/mutation/deleteTag.ts
+++ b/frontend/src/app/(protected)/tags/_lib/mutation/deleteTag.ts
@@ -1,10 +1,4 @@
-export async function deleteTag({ id }: { id: number }): Promise<void> {
-  const response = await fetch(`/api/tags/${id}`, {
-    method: 'DELETE',
-  });
+import { mutateResource } from '@/lib/api/mutateResource';
 
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-}
+export const deleteTag = ({ id }: { id: number }): Promise<void> =>
+  mutateResource(`/api/tags/${id}`, 'DELETE');

--- a/frontend/src/app/(protected)/tags/_lib/mutation/updateTag.ts
+++ b/frontend/src/app/(protected)/tags/_lib/mutation/updateTag.ts
@@ -1,18 +1,7 @@
-import { Tag, TagFormData, tagSchema } from '@/app/(protected)/tags/_types';
+import { type Tag, type TagFormData, tagSchema } from '@/app/(protected)/tags/_types';
+import { mutateResource } from '@/lib/api/mutateResource';
 
-export async function updateTag(data: TagFormData & { id: number }): Promise<Tag> {
+export const updateTag = (data: TagFormData & { id: number }): Promise<Tag> => {
   const { id, ...updateData } = data;
-  const response = await fetch(`/api/tags/${id}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(updateData),
-  });
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const res = await response.json();
-  return tagSchema.parse(res);
-}
+  return mutateResource(`/api/tags/${id}`, 'PUT', updateData, tagSchema);
+};

--- a/frontend/src/app/(protected)/tags/_lib/query/fetchTags.ts
+++ b/frontend/src/app/(protected)/tags/_lib/query/fetchTags.ts
@@ -1,13 +1,4 @@
 import { tagSchema, type Tag } from '@/app/(protected)/tags/_types';
+import { fetchResource } from '@/lib/api/fetchResource';
 
-export async function fetchTags(): Promise<Tag[]> {
-  const response = await fetch('/api/tags');
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const data = await response.json();
-  return tagSchema.array().parse(data);
-}
+export const fetchTags = (): Promise<Tag[]> => fetchResource('/api/tags', tagSchema.array());

--- a/frontend/src/app/(protected)/top/loading.tsx
+++ b/frontend/src/app/(protected)/top/loading.tsx
@@ -1,0 +1,53 @@
+export default function TopLoading() {
+  return (
+    <>
+      {/* ページ見出し */}
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-8">
+        <div className="h-10 w-24 animate-pulse rounded-lg bg-slate-200" />
+      </div>
+
+      {/* 最近作成した本 */}
+      <section className="mb-10">
+        <div className="flex items-center justify-between mb-4">
+          <div className="h-7 w-44 animate-pulse rounded bg-slate-200" />
+          <div className="h-5 w-20 animate-pulse rounded bg-slate-200" />
+        </div>
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-5">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="flex flex-col gap-2">
+              <div className="aspect-[2/3] animate-pulse rounded-lg bg-slate-200" />
+              <div className="h-4 w-3/4 animate-pulse rounded bg-slate-200" />
+              <div className="h-3 w-1/2 animate-pulse rounded bg-slate-200" />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* 最近作成したリスト */}
+      <section className="mb-10">
+        <div className="flex items-center justify-between mb-4">
+          <div className="h-7 w-52 animate-pulse rounded bg-slate-200" />
+          <div className="h-5 w-20 animate-pulse rounded bg-slate-200" />
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-24 animate-pulse rounded-lg bg-slate-200" />
+          ))}
+        </div>
+      </section>
+
+      {/* 最近作成したカード */}
+      <section>
+        <div className="flex items-center justify-between mb-4">
+          <div className="h-7 w-52 animate-pulse rounded bg-slate-200" />
+          <div className="h-5 w-20 animate-pulse rounded bg-slate-200" />
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <div key={i} className="h-28 animate-pulse rounded-lg bg-slate-200" />
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/frontend/src/app/(protected)/users/[id]/followers/loading.tsx
+++ b/frontend/src/app/(protected)/users/[id]/followers/loading.tsx
@@ -1,0 +1,23 @@
+export default function FollowersLoading() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="max-w-2xl mx-auto space-y-6">
+        {/* 戻るリンク */}
+        <div className="h-5 w-52 animate-pulse rounded bg-slate-200" />
+
+        {/* ページタイトル */}
+        <div className="h-9 w-32 animate-pulse rounded bg-slate-200" />
+
+        {/* ユーザー一覧 */}
+        <div className="bg-white rounded-lg border border-slate-200 divide-y divide-slate-200">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-4 p-4">
+              <div className="w-12 h-12 shrink-0 rounded-full animate-pulse bg-slate-200" />
+              <div className="h-5 w-32 animate-pulse rounded bg-slate-200" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(protected)/users/[id]/followers/page.tsx
+++ b/frontend/src/app/(protected)/users/[id]/followers/page.tsx
@@ -14,23 +14,22 @@ export default async function FollowersPage({ params }: FollowersPageProps) {
   const { id } = await params;
   const queryClient = createServerQueryClient();
 
-  // ユーザー情報をprefetch
-  await queryClient.prefetchQuery({
-    queryKey: queryKeys.users.detail(id),
-    queryFn: async () => {
-      const data = await authenticatedRequest(`/users/${id}`);
-      return userWithStatsSchema.parse(data);
-    },
-  });
-
-  // フォロワー一覧をprefetch
-  await queryClient.prefetchQuery({
-    queryKey: queryKeys.users.followers(id),
-    queryFn: async () => {
-      const data = await authenticatedRequest(`/users/${id}/followers`);
-      return userSchema.array().parse(data);
-    },
-  });
+  await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: queryKeys.users.detail(id),
+      queryFn: async () => {
+        const data = await authenticatedRequest(`/users/${id}`);
+        return userWithStatsSchema.parse(data);
+      },
+    }),
+    queryClient.prefetchQuery({
+      queryKey: queryKeys.users.followers(id),
+      queryFn: async () => {
+        const data = await authenticatedRequest(`/users/${id}/followers`);
+        return userSchema.array().parse(data);
+      },
+    }),
+  ]);
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/frontend/src/app/(protected)/users/[id]/following/loading.tsx
+++ b/frontend/src/app/(protected)/users/[id]/following/loading.tsx
@@ -1,0 +1,23 @@
+export default function FollowingLoading() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="max-w-2xl mx-auto space-y-6">
+        {/* 戻るリンク */}
+        <div className="h-5 w-52 animate-pulse rounded bg-slate-200" />
+
+        {/* ページタイトル */}
+        <div className="h-9 w-32 animate-pulse rounded bg-slate-200" />
+
+        {/* ユーザー一覧 */}
+        <div className="bg-white rounded-lg border border-slate-200 divide-y divide-slate-200">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-4 p-4">
+              <div className="w-12 h-12 shrink-0 rounded-full animate-pulse bg-slate-200" />
+              <div className="h-5 w-32 animate-pulse rounded bg-slate-200" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(protected)/users/[id]/following/page.tsx
+++ b/frontend/src/app/(protected)/users/[id]/following/page.tsx
@@ -13,23 +13,22 @@ export default async function FollowingPage({ params }: FollowingPageProps) {
   const { id } = await params;
   const queryClient = createServerQueryClient();
 
-  // ユーザー情報をprefetch
-  await queryClient.prefetchQuery({
-    queryKey: queryKeys.users.detail(id),
-    queryFn: async () => {
-      const data = await authenticatedRequest(`/users/${id}`);
-      return userWithStatsSchema.parse(data);
-    },
-  });
-
-  // フォロー中のユーザー一覧をprefetch
-  await queryClient.prefetchQuery({
-    queryKey: queryKeys.users.following(id),
-    queryFn: async () => {
-      const data = await authenticatedRequest(`/users/${id}/following`);
-      return userSchema.array().parse(data);
-    },
-  });
+  await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: queryKeys.users.detail(id),
+      queryFn: async () => {
+        const data = await authenticatedRequest(`/users/${id}`);
+        return userWithStatsSchema.parse(data);
+      },
+    }),
+    queryClient.prefetchQuery({
+      queryKey: queryKeys.users.following(id),
+      queryFn: async () => {
+        const data = await authenticatedRequest(`/users/${id}/following`);
+        return userSchema.array().parse(data);
+      },
+    }),
+  ]);
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/frontend/src/app/(protected)/users/[id]/loading.tsx
+++ b/frontend/src/app/(protected)/users/[id]/loading.tsx
@@ -1,0 +1,78 @@
+export default function UserDetailLoading() {
+  return (
+    <div className="space-y-8">
+      {/* ユーザープロフィールカード */}
+      <div className="space-y-6">
+        <div className="bg-white rounded-lg border border-slate-200 p-8">
+          <div className="flex flex-col items-center">
+            {/* アバター */}
+            <div className="w-32 h-32 rounded-full animate-pulse bg-slate-200 mb-4" />
+
+            {/* ユーザー名 */}
+            <div className="h-7 w-32 animate-pulse rounded bg-slate-200 mb-4" />
+
+            {/* フォローボタン */}
+            <div className="h-10 w-28 animate-pulse rounded-lg bg-slate-200 mb-6" />
+
+            {/* 統計情報 */}
+            <div className="flex gap-8">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div key={i} className="flex flex-col items-center">
+                  <div className="flex items-center gap-2 mb-1">
+                    <div className="w-5 h-5 animate-pulse rounded bg-slate-200" />
+                    <div className="h-7 w-8 animate-pulse rounded bg-slate-200" />
+                  </div>
+                  <div className="h-4 w-16 animate-pulse rounded bg-slate-200" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 本一覧 */}
+      <div className="space-y-6">
+        <div className="h-7 w-20 animate-pulse rounded bg-slate-200" />
+        <div className="space-y-4">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <div key={i} className="p-4 bg-white rounded-xl border border-slate-200">
+              <div className="flex flex-col sm:flex-row gap-4 sm:gap-6">
+                <div className="w-32 h-44 shrink-0 animate-pulse rounded-lg bg-slate-200" />
+                <div className="flex flex-col gap-3 flex-1">
+                  <div className="h-5 w-3/4 animate-pulse rounded bg-slate-200" />
+                  <div className="h-4 w-1/2 animate-pulse rounded bg-slate-200" />
+                  <div className="h-4 w-full animate-pulse rounded bg-slate-200" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* 公開リスト */}
+      <div className="space-y-6">
+        <div className="h-7 w-28 animate-pulse rounded bg-slate-200" />
+        <div className="space-y-4">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <div key={i} className="rounded-lg border border-slate-200 bg-white p-4">
+              <div className="flex flex-col sm:flex-row gap-4">
+                <div className="shrink-0 w-12 h-12 animate-pulse rounded-lg bg-slate-200" />
+                <div className="flex flex-col gap-2 min-w-0 flex-1">
+                  <div className="h-5 w-3/4 animate-pulse rounded bg-slate-200" />
+                  <div className="h-4 w-full animate-pulse rounded bg-slate-200" />
+                  <div className="flex flex-wrap items-center gap-4">
+                    <div className="h-3 w-20 animate-pulse rounded bg-slate-200" />
+                    <div className="h-3 w-28 animate-pulse rounded bg-slate-200" />
+                  </div>
+                </div>
+                <div className="sm:self-end sm:ml-auto">
+                  <div className="h-10 w-full sm:w-16 animate-pulse rounded-lg bg-slate-200" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(protected)/users/[id]/page.tsx
+++ b/frontend/src/app/(protected)/users/[id]/page.tsx
@@ -15,32 +15,29 @@ export default async function UserPage({ params }: UserPageProps) {
   const { id } = await params;
   const queryClient = createServerQueryClient();
 
-  // ユーザー情報をprefetch
-  await queryClient.prefetchQuery({
-    queryKey: queryKeys.users.detail(id),
-    queryFn: async () => {
-      const data = await authenticatedRequest(`/users/${id}`);
-      return userWithStatsSchema.parse(data);
-    },
-  });
-
-  // ユーザーの公開本一覧をprefetch
-  await queryClient.prefetchQuery({
-    queryKey: queryKeys.users.books(id),
-    queryFn: async () => {
-      const data = await authenticatedRequest(`/users/${id}/books`);
-      return bookSchema.array().parse(data);
-    },
-  });
-
-  // ユーザーの公開リスト一覧をprefetch
-  await queryClient.prefetchQuery({
-    queryKey: queryKeys.users.lists(id),
-    queryFn: async () => {
-      const data = await authenticatedRequest(`/users/${id}/lists`);
-      return listSchema.array().parse(data);
-    },
-  });
+  await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: queryKeys.users.detail(id),
+      queryFn: async () => {
+        const data = await authenticatedRequest(`/users/${id}`);
+        return userWithStatsSchema.parse(data);
+      },
+    }),
+    queryClient.prefetchQuery({
+      queryKey: queryKeys.users.books(id),
+      queryFn: async () => {
+        const data = await authenticatedRequest(`/users/${id}/books`);
+        return bookSchema.array().parse(data);
+      },
+    }),
+    queryClient.prefetchQuery({
+      queryKey: queryKeys.users.lists(id),
+      queryFn: async () => {
+        const data = await authenticatedRequest(`/users/${id}/lists`);
+        return listSchema.array().parse(data);
+      },
+    }),
+  ]);
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/frontend/src/app/(protected)/users/_lib/mutation/followUser.ts
+++ b/frontend/src/app/(protected)/users/_lib/mutation/followUser.ts
@@ -1,16 +1,7 @@
-interface FollowResponse {
-  message: string;
-}
+import { z } from 'zod';
+import { mutateResource } from '@/lib/api/mutateResource';
 
-export async function followUser(userId: string): Promise<FollowResponse> {
-  const response = await fetch(`/api/users/${userId}/follow`, {
-    method: 'POST',
-  });
+const followResponseSchema = z.object({ message: z.string() });
 
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  return response.json();
-}
+export const followUser = (userId: string) =>
+  mutateResource(`/api/users/${userId}/follow`, 'POST', undefined, followResponseSchema);

--- a/frontend/src/app/(protected)/users/_lib/mutation/unfollowUser.ts
+++ b/frontend/src/app/(protected)/users/_lib/mutation/unfollowUser.ts
@@ -1,16 +1,7 @@
-interface FollowResponse {
-  message: string;
-}
+import { z } from 'zod';
+import { mutateResource } from '@/lib/api/mutateResource';
 
-export async function unfollowUser(userId: string): Promise<FollowResponse> {
-  const response = await fetch(`/api/users/${userId}/follow`, {
-    method: 'DELETE',
-  });
+const followResponseSchema = z.object({ message: z.string() });
 
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  return response.json();
-}
+export const unfollowUser = (userId: string) =>
+  mutateResource(`/api/users/${userId}/follow`, 'DELETE', undefined, followResponseSchema);

--- a/frontend/src/app/(protected)/users/_lib/query/fetchFollowStatus.ts
+++ b/frontend/src/app/(protected)/users/_lib/query/fetchFollowStatus.ts
@@ -1,13 +1,5 @@
-import { FollowStatus, followStatusSchema } from '@/app/(protected)/users/_types';
+import { type FollowStatus, followStatusSchema } from '@/app/(protected)/users/_types';
+import { fetchResource } from '@/lib/api/fetchResource';
 
-export async function fetchFollowStatus(userId: string): Promise<FollowStatus> {
-  const response = await fetch(`/api/users/${userId}/follow-status`);
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const data = await response.json();
-  return followStatusSchema.parse(data);
-}
+export const fetchFollowStatus = (userId: string): Promise<FollowStatus> =>
+  fetchResource(`/api/users/${userId}/follow-status`, followStatusSchema);

--- a/frontend/src/app/(protected)/users/_lib/query/fetchFollowers.ts
+++ b/frontend/src/app/(protected)/users/_lib/query/fetchFollowers.ts
@@ -1,13 +1,5 @@
-import { User, userSchema } from '@/app/(protected)/users/_types';
+import { type User, userSchema } from '@/app/(protected)/users/_types';
+import { fetchResource } from '@/lib/api/fetchResource';
 
-export async function fetchFollowers(userId: string): Promise<User[]> {
-  const response = await fetch(`/api/users/${userId}/followers`);
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const data = await response.json();
-  return userSchema.array().parse(data);
-}
+export const fetchFollowers = (userId: string): Promise<User[]> =>
+  fetchResource(`/api/users/${userId}/followers`, userSchema.array());

--- a/frontend/src/app/(protected)/users/_lib/query/fetchFollowing.ts
+++ b/frontend/src/app/(protected)/users/_lib/query/fetchFollowing.ts
@@ -1,13 +1,5 @@
-import { User, userSchema } from '@/app/(protected)/users/_types';
+import { type User, userSchema } from '@/app/(protected)/users/_types';
+import { fetchResource } from '@/lib/api/fetchResource';
 
-export async function fetchFollowing(userId: string): Promise<User[]> {
-  const response = await fetch(`/api/users/${userId}/following`);
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const data = await response.json();
-  return userSchema.array().parse(data);
-}
+export const fetchFollowing = (userId: string): Promise<User[]> =>
+  fetchResource(`/api/users/${userId}/following`, userSchema.array());

--- a/frontend/src/app/(protected)/users/_lib/query/fetchUser.ts
+++ b/frontend/src/app/(protected)/users/_lib/query/fetchUser.ts
@@ -1,13 +1,5 @@
 import { userWithStatsSchema, type UserWithStats } from '@/app/(protected)/users/_types';
+import { fetchResource } from '@/lib/api/fetchResource';
 
-export async function fetchUser(id: string): Promise<UserWithStats> {
-  const response = await fetch(`/api/users/${id}`);
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const data = await response.json();
-  return userWithStatsSchema.parse(data);
-}
+export const fetchUser = (id: string): Promise<UserWithStats> =>
+  fetchResource(`/api/users/${id}`, userWithStatsSchema);

--- a/frontend/src/app/(protected)/users/_lib/query/fetchUserBooks.ts
+++ b/frontend/src/app/(protected)/users/_lib/query/fetchUserBooks.ts
@@ -1,13 +1,5 @@
 import { bookSchema, type Book } from '@/schemas/book';
+import { fetchResource } from '@/lib/api/fetchResource';
 
-export async function fetchUserBooks(id: string): Promise<Book[]> {
-  const response = await fetch(`/api/users/${id}/books`);
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const data = await response.json();
-  return bookSchema.array().parse(data);
-}
+export const fetchUserBooks = (id: string): Promise<Book[]> =>
+  fetchResource(`/api/users/${id}/books`, bookSchema.array());

--- a/frontend/src/app/(protected)/users/_lib/query/fetchUserLists.ts
+++ b/frontend/src/app/(protected)/users/_lib/query/fetchUserLists.ts
@@ -1,13 +1,5 @@
 import { listSchema, type List } from '@/schemas/list';
+import { fetchResource } from '@/lib/api/fetchResource';
 
-export async function fetchUserLists(id: string): Promise<List[]> {
-  const response = await fetch(`/api/users/${id}/lists`);
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const data = await response.json();
-  return listSchema.array().parse(data);
-}
+export const fetchUserLists = (id: string): Promise<List[]> =>
+  fetchResource(`/api/users/${id}/lists`, listSchema.array());

--- a/frontend/src/lib/api/fetchResource.ts
+++ b/frontend/src/lib/api/fetchResource.ts
@@ -1,0 +1,16 @@
+import type { ZodType } from 'zod';
+
+/**
+ * APIからリソースを取得し、Zodスキーマでバリデーションして返す
+ */
+export async function fetchResource<T>(endpoint: string, schema: ZodType<T>): Promise<T> {
+  const response = await fetch(endpoint);
+
+  if (!response.ok) {
+    const { error } = await response.json();
+    throw new Error(error);
+  }
+
+  const data = await response.json();
+  return schema.parse(data);
+}

--- a/frontend/src/lib/api/mutateResource.ts
+++ b/frontend/src/lib/api/mutateResource.ts
@@ -1,0 +1,28 @@
+import type { ZodType } from 'zod';
+
+/**
+ * APIへのミューテーション（POST/PUT/DELETE）を実行し、Zodスキーマでバリデーションして返す
+ * スキーマを省略した場合はvoidを返す（DELETE用）
+ */
+export async function mutateResource<T>(
+  endpoint: string,
+  method: 'POST' | 'PUT' | 'DELETE',
+  body?: unknown,
+  schema?: ZodType<T>,
+): Promise<T> {
+  const response = await fetch(endpoint, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    ...(body !== undefined && { body: JSON.stringify(body) }),
+  });
+
+  if (!response.ok) {
+    const { error } = await response.json();
+    throw new Error(error);
+  }
+
+  if (!schema) return undefined as T;
+
+  const data = await response.json();
+  return schema.parse(data);
+}

--- a/frontend/src/lib/fetchProfile.ts
+++ b/frontend/src/lib/fetchProfile.ts
@@ -1,13 +1,4 @@
 import { userSchema, type User } from '@/schemas/user';
+import { fetchResource } from '@/lib/api/fetchResource';
 
-export async function fetchProfile(): Promise<User> {
-  const response = await fetch('/api/profiles');
-
-  if (!response.ok) {
-    const { error } = await response.json();
-    throw new Error(error);
-  }
-
-  const data = await response.json();
-  return userSchema.parse(data);
-}
+export const fetchProfile = (): Promise<User> => fetchResource('/api/profiles', userSchema);


### PR DESCRIPTION
## Summary
- `fetchResource` / `mutateResource` ユーティリティを作成し、全ドメインのfetch/mutation関数を共通化（66ファイル、905行追加/670行削除）
- 全主要ページに `loading.tsx`（スケルトンUI）を追加し、体感表示速度を改善
- 書籍・リスト詳細ページのハイドレーションエラーを修正（`isOwner` の遅延評価）
- 複数の `prefetchQuery` を `Promise.all` で並列化
- カード一覧UIをリニューアル（個別カードスタイル + Plusアイコンボタン）
- `loading.tsx` 追加に伴うe2eテストのフレーキー問題を修正

## 主な変更

### fetch/mutation共通化
- `frontend/src/lib/api/fetchResource.ts` - GET用共通ユーティリティ
- `frontend/src/lib/api/mutateResource.ts` - POST/PUT/DELETE用共通ユーティリティ
- 全ドメイン（Books, Cards, Lists, Tags, Categories, Statuses, Users, Settings, ListBooks）の個別関数を1〜7行のラッパーに簡略化

### loading.tsx追加（11ページ）
- top, dashboard, books, books/[id], lists, lists/[id], cards, cards/[id], users/[id], users/[id]/following, users/[id]/followers

### パフォーマンス改善
- books/[id], lists/[id], users/[id], users/[id]/following, users/[id]/followers の prefetch を `Promise.all` で並列化

### バグ修正
- 書籍・リスト詳細ページのハイドレーションエラー（`useEffect` + `useState` で `isOwner` を遅延評価）
- e2eテストでスケルトンUI表示中のデータ読み込み完了待機を追加

## Test plan
- [x] `make e2e` で全37テストがパス
- [x] 各ページでスケルトンUIが正しく表示されることを目視確認
- [x] スマホサイズでレスポンシブ表示が崩れないことを確認
- [x] 書籍・リスト詳細ページでハイドレーションエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)