### PR TITLE
fix: books/searchで親のloading.tsxが適用される問題を修正

### DIFF
--- a/frontend/src/app/(protected)/books/search/loading.tsx
+++ b/frontend/src/app/(protected)/books/search/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return null;
+}


### PR DESCRIPTION
## Summary
- `books/search` に `return null` の `loading.tsx` を配置し、親の `books/loading.tsx` スケルトンが本番環境で意図せず表示される問題を修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)