### PR TITLE
fix: books/searchのスケルトン表示問題を修正

### DIFF
--- a/frontend/src/app/(protected)/books/search/loading.tsx
+++ b/frontend/src/app/(protected)/books/search/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return null;
+}


### PR DESCRIPTION
## Summary
- `books/search` で親の `books/loading.tsx` が本番環境で意図せず適用される問題を修正
- `return null` の `loading.tsx` を配置して親のスケルトン継承を無効化

## Test plan
- [ ] 本番ビルドで `/books/search` にスケルトンが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)